### PR TITLE
fix(ci): pass GitHub App token to auto-tag workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -13,3 +13,6 @@ jobs:
     uses: tylerbutler/actions/.github/workflows/auto-tag.yml@c697a813534c6364a835de8e2ed2c4e0c3638bbe # ratchet:tylerbutler/actions/.github/workflows/auto-tag.yml@main
     with:
       create-release: true
+    secrets:
+      app-id: ${{ secrets.RELEASE_APP_ID }}
+      app-private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Pass `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` secrets to the reusable auto-tag workflow
- Tags created with the default `GITHUB_TOKEN` don't trigger other workflows (GitHub limitation), so the publish workflow never ran after the v0.1.0 release PR was merged

## Test plan
- [ ] Merge this PR, then trigger a new release to verify the publish workflow runs