### PR TITLE
feat: add npm publishing with talc

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: "Whether to setup Node.js for JavaScript target"
     required: false
     default: "false"
+  registry-url:
+    description: "npm registry URL (used with node input for publishing)"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -24,6 +28,7 @@ runs:
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # ratchet:actions/setup-node@v4
       with:
         node-version: "22"
+        registry-url: ${{ inputs.registry-url }}
 
     - name: Cache Gleam dependencies
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # ratchet:actions/cache@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,11 +4,15 @@ on:
   push:
     tags: ['v*']
 
+permissions:
+  contents: read
+  id-token: write # required for npm provenance attestation
+
 jobs:
   test:
     uses: ./.github/workflows/ci.yml
 
-  publish:
+  publish-hex:
     needs: test
     runs-on: ubuntu-latest
     steps:
@@ -21,3 +25,22 @@ jobs:
         run: gleam publish --yes
         env:
           HEXPM_API_KEY: ${{ secrets.HEXPM_API_KEY }}
+
+  publish-npm:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+
+      - name: Setup environment
+        uses: ./.github/actions/setup
+        with:
+          node: "true"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Build and publish to npm
+        run: |
+          gleam build --target javascript
+          gleam run -m talc -- publish --provenance=true --access=public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ erl_crash.dump
 # Node.js (if using JavaScript target)
 node_modules/
 
+# talc npm package output
+npm_dist/
+
 # IDE
 .idea/
 *.swp

--- a/gleam.toml
+++ b/gleam.toml
@@ -19,3 +19,4 @@ gleam_json = ">= 3.1.0 and < 4.0.0"
 [dev-dependencies]
 startest = ">= 0.8.0 and < 1.0.0"
 qcheck = ">= 1.0.0 and < 2.0.0"
+talc = { git = "https://github.com/tylerbutler/talc.git", ref = "main" }

--- a/justfile
+++ b/justfile
@@ -67,11 +67,29 @@ changelog-preview:
 changelog:
     changie merge
 
+# === NPM PACKAGING (talc) ===
+
+# Generate npm package in npm_dist/
+npm-generate:
+    gleam build --target javascript && gleam run -m talc -- generate
+
+# Check talc configuration without writing files
+npm-check:
+    gleam build --target javascript && gleam run -m talc -- check
+
+# Pack npm tarball
+npm-pack:
+    gleam build --target javascript && gleam run -m talc -- pack
+
+# Dry-run npm publish
+npm-publish-dry:
+    gleam build --target javascript && gleam run -m talc -- publish --dry-run=true
+
 # === MAINTENANCE ===
 
 # Remove build artifacts
 clean:
-    rm -rf build
+    rm -rf build npm_dist
 
 # === CI ===
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -12,17 +12,19 @@ packages = [
   { name = "gleam_javascript", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_javascript", source = "hex", outer_checksum = "EF6C77A506F026C6FB37941889477CD5E4234FCD4337FF0E9384E297CB8F97EB" },
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
   { name = "gleam_otp", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_stdlib"], otp_app = "gleam_otp", source = "hex", outer_checksum = "BA6A294E295E428EC1562DC1C11EA7530DCB981E8359134BEABC8493B7B2258E" },
+  { name = "gleam_package_interface", version = "3.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_package_interface", source = "hex", outer_checksum = "8F2D19DE9876D9401BB0626260958A6B1580BB233489C32831FE74CE0ACAE8B4" },
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
-  { name = "gleam_stdlib", version = "0.68.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "F7FAEBD8EF260664E86A46C8DBA23508D1D11BB3BCC6EE1B89B3BC3E5C83FF1E" },
+  { name = "gleam_stdlib", version = "0.70.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86949BF5D1F0E4AC0AB5B06F235D8A5CC11A2DFC33BF22F752156ED61CA7D0FF" },
   { name = "gleam_time", version = "1.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "56DB0EF9433826D3B99DB0B4AF7A2BFED13D09755EC64B1DAAB46F804A9AD47D" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
   { name = "interior", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "interior", source = "hex", outer_checksum = "EE2728791E34400CB3CD986B6AD0E02A2F970F50B5ED59896E2820702C7DDD29" },
   { name = "prng", version = "5.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "prng", source = "hex", outer_checksum = "29DA88BCFB54D06DD1472951DF101E9524878056D139DA2616B04350B403CE10" },
   { name = "qcheck", version = "1.0.4", build_tools = ["gleam"], requirements = ["exception", "gleam_regexp", "gleam_stdlib", "gleam_yielder", "prng"], otp_app = "qcheck", source = "hex", outer_checksum = "BD9B18C1602FBC667E3E139ED270458F8C743ED791F892CC90989CE10478C4FA" },
-  { name = "simplifile", version = "2.3.2", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "E049B4DACD4D206D87843BCF4C775A50AE0F50A52031A2FFB40C9ED07D6EC70A" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
   { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
+  { name = "talc", version = "0.1.0", build_tools = ["gleam"], requirements = ["argv", "gleam_json", "gleam_package_interface", "gleam_stdlib", "glint", "simplifile", "tom"], source = "git", repo = "https://github.com/tylerbutler/talc.git", commit = "4584abf0b922cbce54694ca86b28628f4d5e6d3b" },
   { name = "tom", version = "2.0.1", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "90791DA4AACE637E30081FE77049B8DB850FBC8CACC31515376BCC4E59BE1DD2" },
 ]
 
@@ -31,3 +33,4 @@ gleam_json = { version = ">= 3.1.0 and < 4.0.0" }
 gleam_stdlib = { version = ">= 0.48.0 and < 2.0.0" }
 qcheck = { version = ">= 1.0.0 and < 2.0.0" }
 startest = { version = ">= 0.8.0 and < 1.0.0" }
+talc = { git = "https://github.com/tylerbutler/talc.git", ref = "main" }

--- a/talc.toml
+++ b/talc.toml
@@ -1,0 +1,2 @@
+[package]
+scope = "@tylerbu"

--- a/test/property/serialization_property_test.gleam
+++ b/test/property/serialization_property_test.gleam
@@ -268,13 +268,11 @@ pub fn version_vector_json_round_trip__test() {
     fn(pair) {
       let #(a, b) = pair
       let vv =
-        list.fold(list.range(1, a), version_vector.new(), fn(v, _) {
+        int.range(1, a, version_vector.new(), fn(v, _) {
           version_vector.increment(v, "A")
         })
       let vv2 =
-        list.fold(list.range(1, b), vv, fn(v, _) {
-          version_vector.increment(v, "B")
-        })
+        int.range(1, b, vv, fn(v, _) { version_vector.increment(v, "B") })
       let json_str = json.to_string(version_vector.to_json(vv2))
       let decoded = version_vector.from_json(json_str)
       case decoded {


### PR DESCRIPTION
## Summary

Add npm publishing support using [talc](https://github.com/tylerbutler/talc) so the library is available as `@tylerbu/lattice_crdt` on npm.

## Changes

- **gleam.toml** — added `talc` as a git dev-dependency
- **talc.toml** — new config file setting npm scope to `@tylerbu`
- **.gitignore** — added `npm_dist/` output directory
- **justfile** — added recipes: `npm-generate`, `npm-check`, `npm-pack`, `npm-publish-dry`; `clean` now removes `npm_dist/`
- **.github/actions/setup/action.yml** — added `registry-url` input for npm auth during CI
- **.github/workflows/publish.yml** — added `publish-npm` job (runs in parallel with Hex publish on tag push)

## Setup Required

Add an `NPM_TOKEN` secret in GitHub repo settings (Settings → Secrets → Actions) with an npm access token that has publish permissions for the `@tylerbu` scope.

## Local Usage

```bash
just npm-check        # validate talc config
just npm-generate     # create npm_dist/
just npm-publish-dry  # dry-run publish
```