### PR TITLE
fix(crdt): add zombie-safe tombstone pruning for LWWMap

### DIFF
--- a/.changes/unreleased/lattice_maps-Added-pruned-timestamp-accessor.yaml
+++ b/.changes/unreleased/lattice_maps-Added-pruned-timestamp-accessor.yaml
@@ -1,0 +1,8 @@
+project: lattice_maps
+kind: Added
+body: |-
+  Add `lww_map.pruned_timestamp()` accessor
+
+  Returns the highest stable timestamp passed to `prune`, useful for monitoring
+  pruning state and debugging merge behavior.
+time: 2026-04-08T21:53:33.000000000+00:00

--- a/.changes/unreleased/lattice_maps-Fixed-lww-map-zombie-pruning.yaml
+++ b/.changes/unreleased/lattice_maps-Fixed-lww-map-zombie-pruning.yaml
@@ -1,0 +1,11 @@
+project: lattice_maps
+kind: Fixed
+body: |-
+  LWWMap `prune` now prevents zombie resurrections on merge
+
+  `prune` records a `pruned_timestamp` in the LWWMap. During `merge`, entries from
+  remote replicas with timestamps at or below the other side's pruned threshold are
+  automatically discarded, preventing deleted keys from reappearing. JSON
+  serialization is bumped to v2 to persist the pruned timestamp; `from_json` still
+  accepts v1 (with pruned timestamp defaulting to 0).
+time: 2026-04-08T21:53:33.000000000+00:00

--- a/packages/lattice_maps/src/lattice_maps/lww_map.gleam
+++ b/packages/lattice_maps/src/lattice_maps/lww_map.gleam
@@ -20,8 +20,9 @@
 ////
 //// Removing a key creates a tombstone that persists until pruned. Use
 //// `tombstone_count` to monitor growth and `prune` to reclaim space once all
-//// replicas have synced past a stable timestamp.
-//// See [#18](https://github.com/tylerbutler/lattice/issues/18) for details.
+//// replicas have synced past a stable timestamp. The embedded
+//// `pruned_timestamp` ensures that stale entries from unsynced replicas are
+//// automatically rejected during merge (zombie prevention).
 
 import gleam/dict
 import gleam/dynamic/decode
@@ -39,18 +40,29 @@ import gleam/string
 /// the entry with the higher timestamp wins for each key; on ties, the first
 /// argument's entry is kept as a consistent tiebreak.
 ///
-/// Note: Tombstones accumulate until pruned. Use `prune` with a stable
-/// timestamp to remove them. See the `prune` function documentation for
-/// the safety contract. A future version will embed a `pruned_timestamp` in
-/// the type for automatic zombie detection on merge; see
-/// [#18](https://github.com/tylerbutler/lattice/issues/18).
+/// Tombstones accumulate until pruned. Use `prune` with a stable timestamp to
+/// remove them. The embedded `pruned_timestamp` enables automatic zombie
+/// detection on merge — entries from remote replicas at or below the pruned
+/// threshold are discarded, preventing deleted keys from resurrecting.
 pub opaque type LWWMap {
-  LWWMap(entries: dict.Dict(String, #(Option(String), Int)))
+  LWWMap(
+    entries: dict.Dict(String, #(Option(String), Int)),
+    pruned_timestamp: Int,
+  )
 }
 
 /// Create a new empty LWW-Map.
 pub fn new() -> LWWMap {
-  LWWMap(entries: dict.new())
+  LWWMap(entries: dict.new(), pruned_timestamp: 0)
+}
+
+/// Return the pruned timestamp.
+///
+/// This is the highest stable timestamp passed to `prune`. Entries from remote
+/// replicas with timestamps at or below this value are treated as zombies during
+/// merge and discarded. A value of `0` means no pruning has occurred.
+pub fn pruned_timestamp(map: LWWMap) -> Int {
+  map.pruned_timestamp
 }
 
 /// Set a key to a value at the given timestamp.
@@ -64,7 +76,10 @@ pub fn set(map: LWWMap, key: String, value: String, timestamp: Int) -> LWWMap {
   }
   case should_update {
     True ->
-      LWWMap(entries: dict.insert(map.entries, key, #(Some(value), timestamp)))
+      LWWMap(
+        ..map,
+        entries: dict.insert(map.entries, key, #(Some(value), timestamp)),
+      )
     False -> map
   }
 }
@@ -88,14 +103,14 @@ pub fn get(map: LWWMap, key: String) -> Result(String, Nil) {
 /// Note: This operation creates a tombstone. Use `tombstone_count` to monitor
 /// growth and `prune` with a stable timestamp to remove tombstones once all
 /// replicas have observed them.
-/// (See https://github.com/tylerbutler/lattice/issues/18)
 pub fn remove(map: LWWMap, key: String, timestamp: Int) -> LWWMap {
   let should_remove = case dict.get(map.entries, key) {
     Error(_) -> True
     Ok(#(_, existing_ts)) -> timestamp > existing_ts
   }
   case should_remove {
-    True -> LWWMap(entries: dict.insert(map.entries, key, #(None, timestamp)))
+    True ->
+      LWWMap(..map, entries: dict.insert(map.entries, key, #(None, timestamp)))
     False -> map
   }
 }
@@ -115,7 +130,6 @@ pub fn keys(map: LWWMap) -> List(String) {
 /// Return the number of tombstoned (removed) entries in the map.
 ///
 /// Useful for monitoring tombstone growth and deciding when to call `prune`.
-/// (See https://github.com/tylerbutler/lattice/issues/18)
 ///
 /// ## Examples
 ///
@@ -139,21 +153,16 @@ pub fn tombstone_count(map: LWWMap) -> Int {
 ///
 /// Removes all tombstone entries (keys with `None` value) whose timestamp is
 /// less than or equal to `stable_timestamp`. Active entries are never removed.
+/// The `pruned_timestamp` is updated monotonically to `max(current, stable_timestamp)`.
 ///
-/// **Safety contract:** The caller must ensure that all replicas have merged
-/// all operations with timestamps up to `stable_timestamp` before pruning.
-/// If this invariant is violated, a pruned tombstone may fail to suppress an
-/// older `set` arriving later via merge, causing the key to reappear with its
-/// old value — known as the "zombie problem" in CRDT literature. If you cannot
-/// guarantee all replicas have synced, prefer a conservative (older)
-/// `stable_timestamp` or wait for the zombie-safe v2 API
-/// ([#18](https://github.com/tylerbutler/lattice/issues/18)).
+/// After pruning, `merge` automatically detects zombie entries — entries from
+/// remote replicas whose timestamps fall at or below the pruned threshold are
+/// discarded, preventing deleted keys from resurrecting.
 ///
-/// **Future:** A v2 of this function will add a `pruned_timestamp` field to the
-/// `LWWMap` type, enabling automatic zombie detection on merge. This is a
-/// breaking change tracked in
-/// [#18](https://github.com/tylerbutler/lattice/issues/18). The current
-/// `prune` function is safe to use today with proper coordination.
+/// The `stable_timestamp` should ideally represent a point that all replicas
+/// have synced past. Using a conservative (older) value is always safe; using
+/// a value ahead of some replica means that replica's stale writes will be
+/// silently dropped on merge (which is the correct behavior for pruned history).
 ///
 /// ## Examples
 ///
@@ -167,13 +176,15 @@ pub fn tombstone_count(map: LWWMap) -> Int {
 /// lww_map.get(pruned, "a")         // -> Ok("alive")
 /// ```
 pub fn prune(map: LWWMap, stable_timestamp: Int) -> LWWMap {
+  let new_pruned = int.max(map.pruned_timestamp, stable_timestamp)
   LWWMap(
     entries: dict.filter(map.entries, fn(_key, entry) {
       case entry {
-        #(None, ts) -> ts > stable_timestamp
+        #(None, ts) -> ts > new_pruned
         #(Some(_), _) -> True
       }
     }),
+    pruned_timestamp: new_pruned,
   )
 }
 
@@ -199,22 +210,38 @@ pub fn values(map: LWWMap) -> List(String) {
 ///
 /// Merge is commutative, associative, and idempotent (a valid CRDT join).
 pub fn merge(a: LWWMap, b: LWWMap) -> LWWMap {
+  let merged_pruned = int.max(a.pruned_timestamp, b.pruned_timestamp)
   let all_keys =
     list.unique(list.append(dict.keys(a.entries), dict.keys(b.entries)))
   let merged =
     list.fold(all_keys, dict.new(), fn(acc, key) {
-      let winner = case dict.get(a.entries, key), dict.get(b.entries, key) {
-        Ok(ea), Ok(eb) -> {
-          choose_winner(ea, eb)
-        }
-        Ok(ea), Error(_) -> ea
-        Error(_), Ok(eb) -> eb
+      let entry = case dict.get(a.entries, key), dict.get(b.entries, key) {
+        Ok(ea), Ok(eb) -> Ok(choose_winner(ea, eb))
+        Ok(ea), Error(_) -> keep_if_not_zombie(ea, b.pruned_timestamp)
+        Error(_), Ok(eb) -> keep_if_not_zombie(eb, a.pruned_timestamp)
         Error(_), Error(_) ->
           panic as "unreachable: key in all_keys but not in either dict"
       }
-      dict.insert(acc, key, winner)
+      case entry {
+        Ok(winner) -> dict.insert(acc, key, winner)
+        Error(Nil) -> acc
+      }
     })
-  LWWMap(entries: merged)
+  LWWMap(entries: merged, pruned_timestamp: merged_pruned)
+}
+
+/// An entry only present on one side is a zombie if its timestamp is at or
+/// below the other side's pruned_timestamp — meaning the other side already
+/// processed and garbage-collected the tombstone that would have suppressed it.
+fn keep_if_not_zombie(
+  entry: #(Option(String), Int),
+  other_pruned: Int,
+) -> Result(#(Option(String), Int), Nil) {
+  let #(_, ts) = entry
+  case ts <= other_pruned {
+    True -> Error(Nil)
+    False -> Ok(entry)
+  }
 }
 
 fn choose_winner(
@@ -247,15 +274,16 @@ fn choose_winner(
 /// Encode a `LWWMap` as a self-describing JSON value.
 ///
 /// Entries are encoded as a JSON array where each element has `key`, `value`
-/// (nullable string for tombstones), and `timestamp` fields.
+/// (nullable string for tombstones), and `timestamp` fields. The
+/// `pruned_timestamp` field records the highest stable timestamp passed to
+/// `prune`, enabling zombie detection after deserialization.
 ///
-/// Format: `{"type": "lww_map", "v": 1, "state": {"entries": [...]}}`
+/// Format: `{"type": "lww_map", "v": 2, "state": {"entries": [...], "pruned_timestamp": N}}`
 ///
 /// The encoded value can be restored with `from_json`.
 pub fn to_json(map: LWWMap) -> json.Json {
-  let LWWMap(entries) = map
   let entries_json =
-    json.array(dict.to_list(entries), fn(pair) {
+    json.array(dict.to_list(map.entries), fn(pair) {
       let #(key, #(opt_value, timestamp)) = pair
       json.object([
         #("key", json.string(key)),
@@ -268,13 +296,20 @@ pub fn to_json(map: LWWMap) -> json.Json {
     })
   json.object([
     #("type", json.string("lww_map")),
-    #("v", json.int(1)),
-    #("state", json.object([#("entries", entries_json)])),
+    #("v", json.int(2)),
+    #(
+      "state",
+      json.object([
+        #("entries", entries_json),
+        #("pruned_timestamp", json.int(map.pruned_timestamp)),
+      ]),
+    ),
   ])
 }
 
 /// Decode a `LWWMap` from a JSON string produced by `to_json`.
 ///
+/// Supports both v1 (no `pruned_timestamp`, defaults to 0) and v2 formats.
 /// Returns `Error` if the string is not valid JSON or does not match the
 /// expected format.
 pub fn from_json(json_string: String) -> Result(LWWMap, json.DecodeError) {
@@ -284,10 +319,24 @@ pub fn from_json(json_string: String) -> Result(LWWMap, json.DecodeError) {
     use timestamp <- decode.field("timestamp", decode.int)
     decode.success(#(key, #(opt_value, timestamp)))
   }
-  let state_decoder = {
+  let v1_state_decoder = {
     use state <- decode.field("state", {
       use entries_list <- decode.field("entries", decode.list(entry_decoder))
-      decode.success(LWWMap(entries: dict.from_list(entries_list)))
+      decode.success(LWWMap(
+        entries: dict.from_list(entries_list),
+        pruned_timestamp: 0,
+      ))
+    })
+    decode.success(state)
+  }
+  let v2_state_decoder = {
+    use state <- decode.field("state", {
+      use entries_list <- decode.field("entries", decode.list(entry_decoder))
+      use pruned_ts <- decode.field("pruned_timestamp", decode.int)
+      decode.success(LWWMap(
+        entries: dict.from_list(entries_list),
+        pruned_timestamp: pruned_ts,
+      ))
     })
     decode.success(state)
   }
@@ -299,13 +348,14 @@ pub fn from_json(json_string: String) -> Result(LWWMap, json.DecodeError) {
   case json.parse(from: json_string, using: envelope_decoder) {
     Error(e) -> Error(e)
     Ok(#(type_tag, version)) ->
-      case type_tag == "lww_map" && version == 1 {
-        True -> json.parse(from: json_string, using: state_decoder)
-        False ->
+      case type_tag == "lww_map", version {
+        True, 1 -> json.parse(from: json_string, using: v1_state_decoder)
+        True, 2 -> json.parse(from: json_string, using: v2_state_decoder)
+        _, _ ->
           Error(
             json.UnableToDecode([
               decode.DecodeError(
-                expected: "type=lww_map and v=1",
+                expected: "type=lww_map and v=1 or v=2",
                 found: type_tag <> " v=" <> int.to_string(version),
                 path: [],
               ),

--- a/packages/lattice_maps/test/map/lww_map_test.gleam
+++ b/packages/lattice_maps/test/map/lww_map_test.gleam
@@ -348,9 +348,8 @@ pub fn prune_preserves_merge_semantics_test() {
   |> expect.to_equal(Ok("from_b"))
 }
 
-pub fn prune_zombie_when_unsynced_test() {
-  // Demonstrates the zombie problem: pruning before sync causes resurrection.
-  // This test documents the known limitation — see issue #18 for the v2 fix.
+pub fn prune_prevents_zombie_on_merge_test() {
+  // Previously this was the zombie problem — now pruned_timestamp prevents it.
   let a =
     lww_map.new()
     |> lww_map.set("key", "val", 5)
@@ -359,11 +358,74 @@ pub fn prune_zombie_when_unsynced_test() {
   // Replica b has NOT seen the remove — only the old set
   let b = lww_map.new() |> lww_map.set("key", "val", 5)
 
-  // Unsafe prune: a prunes the tombstone before b has synced
+  // Prune: a prunes the tombstone, recording pruned_timestamp=10
   let a_pruned = lww_map.prune(a, 10)
 
-  // Merge: b's old set "resurrects" the key (zombie!)
+  // Merge: b's old set at ts=5 ≤ pruned_timestamp=10 is a zombie — rejected
   let merged = lww_map.merge(a_pruned, b)
   lww_map.get(merged, "key")
-  |> expect.to_equal(Ok("val"))
+  |> expect.to_equal(Error(Nil))
+}
+
+pub fn prune_allows_newer_entry_past_threshold_test() {
+  // A pruned at ts=10, but B has a NEW set at ts=15 — this is legitimate
+  let a =
+    lww_map.new()
+    |> lww_map.set("key", "val", 5)
+    |> lww_map.remove("key", 10)
+  let a_pruned = lww_map.prune(a, 10)
+
+  let b = lww_map.new() |> lww_map.set("key", "updated", 15)
+
+  let merged = lww_map.merge(a_pruned, b)
+  lww_map.get(merged, "key")
+  |> expect.to_equal(Ok("updated"))
+}
+
+pub fn pruned_timestamp_propagates_through_merge_test() {
+  // After merge, pruned_timestamp should be max of both sides
+  let a =
+    lww_map.new()
+    |> lww_map.remove("x", 10)
+    |> lww_map.prune(10)
+  let b =
+    lww_map.new()
+    |> lww_map.remove("y", 20)
+    |> lww_map.prune(20)
+
+  let merged = lww_map.merge(a, b)
+  lww_map.pruned_timestamp(merged)
+  |> expect.to_equal(20)
+}
+
+pub fn pruned_timestamp_default_is_zero_test() {
+  lww_map.new()
+  |> lww_map.pruned_timestamp
+  |> expect.to_equal(0)
+}
+
+pub fn prune_is_monotonic_test() {
+  // Pruning with a smaller threshold doesn't regress the pruned_timestamp
+  let m =
+    lww_map.new()
+    |> lww_map.remove("a", 5)
+    |> lww_map.prune(10)
+    |> lww_map.prune(3)
+  lww_map.pruned_timestamp(m)
+  |> expect.to_equal(10)
+}
+
+pub fn prune_zombie_rejected_symmetrically_test() {
+  // Zombie detection works regardless of merge argument order
+  let a =
+    lww_map.new()
+    |> lww_map.set("key", "val", 5)
+    |> lww_map.remove("key", 10)
+    |> lww_map.prune(10)
+
+  let b = lww_map.new() |> lww_map.set("key", "val", 5)
+
+  // Both merge orders should reject the zombie
+  lww_map.merge(a, b) |> lww_map.get("key") |> expect.to_equal(Error(Nil))
+  lww_map.merge(b, a) |> lww_map.get("key") |> expect.to_equal(Error(Nil))
 }

--- a/packages/lattice_maps/test/serialization/lww_map_json_test.gleam
+++ b/packages/lattice_maps/test/serialization/lww_map_json_test.gleam
@@ -60,6 +60,37 @@ pub fn lww_map_round_trip_mixed_active_and_tombstoned_test() {
   }
 }
 
+pub fn lww_map_round_trip_v2_with_pruned_timestamp_test() {
+  let map =
+    lww_map.new()
+    |> lww_map.set("name", "Alice", 1)
+    |> lww_map.remove("old", 5)
+    |> lww_map.prune(5)
+  let json_str = json.to_string(lww_map.to_json(map))
+  let assert Ok(decoded) = lww_map.from_json(json_str)
+
+  // Active entry survives
+  lww_map.get(decoded, "name") |> expect.to_equal(Ok("Alice"))
+  // Tombstone was pruned
+  lww_map.tombstone_count(decoded) |> expect.to_equal(0)
+  // pruned_timestamp survives round-trip
+  lww_map.pruned_timestamp(decoded) |> expect.to_equal(5)
+
+  // Zombie rejected after round-trip
+  let zombie = lww_map.new() |> lww_map.set("old", "zombie", 3)
+  let merged = lww_map.merge(decoded, zombie)
+  lww_map.get(merged, "old") |> expect.to_equal(Error(Nil))
+}
+
+pub fn lww_map_from_json_v1_backward_compatible_test() {
+  // v1 JSON (no pruned_timestamp) should decode with pruned_timestamp=0
+  let v1_json =
+    "{\"type\":\"lww_map\",\"v\":1,\"state\":{\"entries\":[{\"key\":\"a\",\"value\":\"1\",\"timestamp\":5}]}}"
+  let assert Ok(decoded) = lww_map.from_json(v1_json)
+  lww_map.get(decoded, "a") |> expect.to_equal(Ok("1"))
+  lww_map.pruned_timestamp(decoded) |> expect.to_equal(0)
+}
+
 pub fn lww_map_from_json_invalid_test() {
   let result = lww_map.from_json("{invalid json}")
   case result {


### PR DESCRIPTION
## Summary

Closes #18.

Previously, `LWWMap.prune()` removed tombstones but had no mechanism to prevent "zombie" resurrections when merging with an unsynced replica. This adds a `pruned_timestamp` field to the opaque `LWWMap` type, enabling automatic zombie detection during `merge`.

- **`pruned_timestamp` field**: Embedded in the type, monotonically updated by `prune()`, propagated as `max(a, b)` through `merge()`
- **Zombie detection in `merge()`**: Entries only present on one side with timestamps at or below the other side's `pruned_timestamp` are discarded
- **`pruned_timestamp()` accessor**: Exposes the current pruned threshold for monitoring
- **JSON v2 format**: `to_json` now emits `"v": 2` including `pruned_timestamp`; `from_json` accepts both v1 (defaults to 0) and v2 for backward compatibility