### PR TITLE
feat(crdt)!: return explicit errors from crdt.merge on type mismatch

### DIFF
--- a/.changes/unreleased/lattice_maps-Added-merge-error-type.yaml
+++ b/.changes/unreleased/lattice_maps-Added-merge-error-type.yaml
@@ -1,0 +1,9 @@
+project: lattice_maps
+kind: Added
+body: |-
+  Add `MergeError` type and `crdt.type_name` function
+
+  `MergeError` has a single variant `TypeMismatch(expected: String, found: String)`
+  with human-readable CRDT type names. `crdt.type_name(value)` returns the name
+  string for any wrapped `Crdt` value (e.g., `"g_counter"`, `"or_set"`).
+time: 2026-04-08T22:39:57.000000000+00:00

--- a/.changes/unreleased/lattice_maps-Breaking-merge-result-type.yaml
+++ b/.changes/unreleased/lattice_maps-Breaking-merge-result-type.yaml
@@ -1,0 +1,11 @@
+project: lattice_maps
+kind: Breaking
+body: |-
+  `crdt.merge` and `or_map.merge` now return `Result` instead of bare values
+
+  `crdt.merge(a, b)` returns `Result(Crdt, MergeError)` — type mismatches produce
+  `Error(TypeMismatch(expected: ..., found: ...))` instead of silently returning
+  the first argument. `or_map.merge(a, b)` returns `Result(ORMap, MergeError)` —
+  spec mismatches produce the same error. Callers must handle the `Result`;
+  for same-type merges, `let assert Ok(merged) = crdt.merge(a, b)` is idiomatic.
+time: 2026-04-08T22:39:57.000000000+00:00

--- a/examples/src/or_map_example.gleam
+++ b/examples/src/or_map_example.gleam
@@ -66,7 +66,7 @@ pub fn main() {
   io.println("")
 
   // Merge — "page-views" counters merge (5 + 3 = 8), "api-calls" appears
-  let merged = or_map.merge(map_a, map_b)
+  let assert Ok(merged) = or_map.merge(map_a, map_b)
   io.println("Merged map:")
   io.println(
     "  keys: ["

--- a/packages/lattice_crdt/test/integration_test.gleam
+++ b/packages/lattice_crdt/test/integration_test.gleam
@@ -53,7 +53,7 @@ pub fn or_map_with_g_counter_cross_package_test() {
       crdt.CrdtGCounter(g_counter.increment(gc, 5))
     })
 
-  let merged = or_map.merge(map_a, map_b)
+  let assert Ok(merged) = or_map.merge(map_a, map_b)
   let assert Ok(crdt.CrdtGCounter(gc)) = or_map.get(merged, "score")
 
   // Both increments should be preserved after merge
@@ -65,7 +65,7 @@ pub fn crdt_dispatch_merge_heterogeneous_test() {
   // Verify the dispatch module correctly merges same-type CRDTs
   let a = crdt.CrdtGCounter(g_counter.new(rid("a")) |> g_counter.increment(3))
   let b = crdt.CrdtGCounter(g_counter.new(rid("b")) |> g_counter.increment(7))
-  let merged = crdt.merge(a, b)
+  let assert Ok(merged) = crdt.merge(a, b)
 
   let assert crdt.CrdtGCounter(gc) = merged
   g_counter.value(gc)

--- a/packages/lattice_maps/src/lattice_maps/crdt.gleam
+++ b/packages/lattice_maps/src/lattice_maps/crdt.gleam
@@ -17,7 +17,7 @@
 ////
 //// let a = crdt.CrdtGCounter(g_counter.new(replica_id.new("node-a")) |> g_counter.increment(1))
 //// let b = crdt.CrdtGCounter(g_counter.new(replica_id.new("node-b")) |> g_counter.increment(2))
-//// let merged = crdt.merge(a, b)
+//// let assert Ok(merged) = crdt.merge(a, b)
 //// ```
 
 import gleam/dynamic/decode
@@ -56,6 +56,28 @@ pub type Crdt {
   CrdtTwoPSet(TwoPSet(String))
   CrdtOrSet(ORSet(String))
   CrdtVersionVector(VersionVector)
+}
+
+/// Error returned when merging two `Crdt` values of different types.
+///
+/// The `expected` and `found` fields contain human-readable type names
+/// (e.g., `"g_counter"`, `"or_set"`).
+pub type MergeError {
+  TypeMismatch(expected: String, found: String)
+}
+
+/// Return a human-readable type name for a wrapped `Crdt` value.
+pub fn type_name(value: Crdt) -> String {
+  case value {
+    CrdtGCounter(_) -> "g_counter"
+    CrdtPnCounter(_) -> "pn_counter"
+    CrdtLwwRegister(_) -> "lww_register"
+    CrdtMvRegister(_) -> "mv_register"
+    CrdtGSet(_) -> "g_set"
+    CrdtTwoPSet(_) -> "two_p_set"
+    CrdtOrSet(_) -> "or_set"
+    CrdtVersionVector(_) -> "version_vector"
+  }
 }
 
 /// Specifies which leaf CRDT type an `ORMap` holds as its values.
@@ -115,29 +137,27 @@ pub fn matches_spec(value: Crdt, spec: CrdtSpec) -> Bool {
 /// Dispatch merge to the type-specific merge function for matching variants.
 ///
 /// If `a` and `b` hold the same variant, their inner values are merged using
-/// the type-specific merge function.
+/// the type-specific merge function and returned as `Ok(merged)`.
 ///
-/// Note: In 1.x, type mismatches (different variants) silently return `a`
-/// (the local state). This technically breaks strict commutativity, but
-/// prevents the BEAM VM from panicking when encountering bad peer data while
-/// avoiding a breaking change to the `merge` signature.
-/// This fallback behavior will be replaced with explicit `Result` returns in v2.0.
-/// See https://github.com/tylerbutler/lattice/issues/25 for tracking.
-pub fn merge(a: Crdt, b: Crdt) -> Crdt {
+/// If `a` and `b` hold different variants, returns
+/// `Error(TypeMismatch(expected: ..., found: ...))` where `expected` is the
+/// type name of `a` and `found` is the type name of `b`.
+pub fn merge(a: Crdt, b: Crdt) -> Result(Crdt, MergeError) {
   case a, b {
-    CrdtGCounter(ca), CrdtGCounter(cb) -> CrdtGCounter(g_counter.merge(ca, cb))
+    CrdtGCounter(ca), CrdtGCounter(cb) ->
+      Ok(CrdtGCounter(g_counter.merge(ca, cb)))
     CrdtPnCounter(ca), CrdtPnCounter(cb) ->
-      CrdtPnCounter(pn_counter.merge(ca, cb))
+      Ok(CrdtPnCounter(pn_counter.merge(ca, cb)))
     CrdtLwwRegister(ca), CrdtLwwRegister(cb) ->
-      CrdtLwwRegister(lww_register.merge(ca, cb))
+      Ok(CrdtLwwRegister(lww_register.merge(ca, cb)))
     CrdtMvRegister(ca), CrdtMvRegister(cb) ->
-      CrdtMvRegister(mv_register.merge(ca, cb))
-    CrdtGSet(ca), CrdtGSet(cb) -> CrdtGSet(g_set.merge(ca, cb))
-    CrdtTwoPSet(ca), CrdtTwoPSet(cb) -> CrdtTwoPSet(two_p_set.merge(ca, cb))
-    CrdtOrSet(ca), CrdtOrSet(cb) -> CrdtOrSet(or_set.merge(ca, cb))
+      Ok(CrdtMvRegister(mv_register.merge(ca, cb)))
+    CrdtGSet(ca), CrdtGSet(cb) -> Ok(CrdtGSet(g_set.merge(ca, cb)))
+    CrdtTwoPSet(ca), CrdtTwoPSet(cb) -> Ok(CrdtTwoPSet(two_p_set.merge(ca, cb)))
+    CrdtOrSet(ca), CrdtOrSet(cb) -> Ok(CrdtOrSet(or_set.merge(ca, cb)))
     CrdtVersionVector(ca), CrdtVersionVector(cb) ->
-      CrdtVersionVector(version_vector.merge(ca, cb))
-    _, _ -> a
+      Ok(CrdtVersionVector(version_vector.merge(ca, cb)))
+    _, _ -> Error(TypeMismatch(expected: type_name(a), found: type_name(b)))
   }
 }
 

--- a/packages/lattice_maps/src/lattice_maps/or_map.gleam
+++ b/packages/lattice_maps/src/lattice_maps/or_map.gleam
@@ -166,15 +166,15 @@ pub fn values(map: ORMap) -> List(Crdt) {
 /// survives in the merged result. CRDT values are merged per-key using
 /// `crdt.merge` for type-specific convergence.
 ///
-/// Note: In 1.x, if `crdt_spec` mismatches between maps, this function silently
-/// returns `a` (the local state). This technically breaks strict commutativity, but
-/// prevents the BEAM VM from panicking when encountering bad peer data while
-/// avoiding a breaking change to the `merge` signature.
-/// This fallback behavior will be replaced with explicit `Result` returns in v2.0.
-/// See https://github.com/tylerbutler/lattice/issues/25 for tracking.
-pub fn merge(a: ORMap, b: ORMap) -> ORMap {
+/// Returns `Error(TypeMismatch(...))` if the two maps have different
+/// `crdt_spec` values (e.g., one holds counters and the other holds sets).
+pub fn merge(a: ORMap, b: ORMap) -> Result(ORMap, crdt.MergeError) {
   case a.crdt_spec == b.crdt_spec {
-    False -> a
+    False ->
+      Error(crdt.TypeMismatch(
+        expected: spec_to_string(a.crdt_spec),
+        found: spec_to_string(b.crdt_spec),
+      ))
     True -> {
       let merged_key_set = or_set.merge(a.key_set, b.key_set)
       let all_value_keys =
@@ -182,7 +182,11 @@ pub fn merge(a: ORMap, b: ORMap) -> ORMap {
       let merged_values =
         list.fold(all_value_keys, dict.new(), fn(acc, key) {
           let merged_crdt = case valid_value(a, key), valid_value(b, key) {
-            Ok(ca), Ok(cb) -> crdt.merge(ca, cb)
+            Ok(ca), Ok(cb) ->
+              case crdt.merge(ca, cb) {
+                Ok(merged) -> merged
+                Error(_) -> crdt.default_crdt(a.crdt_spec, a.replica_id)
+              }
             Ok(ca), Error(_) -> ca
             Error(_), Ok(cb) -> cb
             Error(_), Error(_) ->
@@ -190,12 +194,12 @@ pub fn merge(a: ORMap, b: ORMap) -> ORMap {
           }
           dict.insert(acc, key, merged_crdt)
         })
-      ORMap(
+      Ok(ORMap(
         replica_id: a.replica_id,
         crdt_spec: a.crdt_spec,
         key_set: merged_key_set,
         values: merged_values,
-      )
+      ))
     }
   }
 }

--- a/packages/lattice_maps/test/map/crdt_dispatch_test.gleam
+++ b/packages/lattice_maps/test/map/crdt_dispatch_test.gleam
@@ -61,7 +61,7 @@ pub fn default_crdt_or_set_test() {
 pub fn merge_g_counter_dispatches_test() {
   let a = CrdtGCounter(g_counter.new(rid("A")) |> g_counter.increment(3))
   let b = CrdtGCounter(g_counter.new(rid("B")) |> g_counter.increment(5))
-  let merged = crdt.merge(a, b)
+  let assert Ok(merged) = crdt.merge(a, b)
   case merged {
     CrdtGCounter(c) -> g_counter.value(c) |> expect.to_equal(8)
     _ -> expect.to_be_true(False)
@@ -71,7 +71,7 @@ pub fn merge_g_counter_dispatches_test() {
 pub fn merge_pn_counter_dispatches_test() {
   let a = CrdtPnCounter(pn_counter.new(rid("A")) |> pn_counter.increment(3))
   let b = CrdtPnCounter(pn_counter.new(rid("B")) |> pn_counter.increment(7))
-  let merged = crdt.merge(a, b)
+  let assert Ok(merged) = crdt.merge(a, b)
   case merged {
     CrdtPnCounter(c) -> pn_counter.value(c) |> expect.to_equal(10)
     _ -> expect.to_be_true(False)
@@ -81,7 +81,7 @@ pub fn merge_pn_counter_dispatches_test() {
 pub fn merge_lww_register_dispatches_test() {
   let a = CrdtLwwRegister(lww_register.new("hello", 1, rid("A")))
   let b = CrdtLwwRegister(lww_register.new("world", 5, rid("B")))
-  let merged = crdt.merge(a, b)
+  let assert Ok(merged) = crdt.merge(a, b)
   case merged {
     CrdtLwwRegister(r) -> lww_register.value(r) |> expect.to_equal("world")
     _ -> expect.to_be_true(False)
@@ -91,7 +91,7 @@ pub fn merge_lww_register_dispatches_test() {
 pub fn merge_g_set_dispatches_test() {
   let a = CrdtGSet(g_set.new() |> g_set.add("x"))
   let b = CrdtGSet(g_set.new() |> g_set.add("y"))
-  let merged = crdt.merge(a, b)
+  let assert Ok(merged) = crdt.merge(a, b)
   case merged {
     CrdtGSet(s) -> {
       g_set.contains(s, "x") |> expect.to_be_true
@@ -104,7 +104,7 @@ pub fn merge_g_set_dispatches_test() {
 pub fn merge_or_set_dispatches_test() {
   let a = CrdtOrSet(or_set.new(rid("A")) |> or_set.add("x"))
   let b = CrdtOrSet(or_set.new(rid("B")) |> or_set.add("y"))
-  let merged = crdt.merge(a, b)
+  let assert Ok(merged) = crdt.merge(a, b)
   case merged {
     CrdtOrSet(s) -> {
       or_set.contains(s, "x") |> expect.to_be_true
@@ -123,7 +123,7 @@ pub fn merge_version_vector_dispatches_test() {
     CrdtVersionVector(
       version_vector.new() |> version_vector.increment(rid("B")),
     )
-  let merged = crdt.merge(a, b)
+  let assert Ok(merged) = crdt.merge(a, b)
   case merged {
     CrdtVersionVector(vv) -> {
       version_vector.get(vv, rid("A")) |> expect.to_equal(1)
@@ -133,11 +133,14 @@ pub fn merge_version_vector_dispatches_test() {
   }
 }
 
-pub fn merge_type_mismatch_returns_first_test() {
+pub fn merge_type_mismatch_returns_error_test() {
   let a = CrdtGCounter(g_counter.new(rid("A")))
   let b = CrdtGSet(g_set.new())
 
-  crdt.merge(a, b) |> expect.to_equal(a)
+  crdt.merge(a, b)
+  |> expect.to_equal(
+    Error(crdt.TypeMismatch(expected: "g_counter", found: "g_set")),
+  )
 }
 
 // --- to_json / from_json round-trip tests ---

--- a/packages/lattice_maps/test/map/or_map_prune_test.gleam
+++ b/packages/lattice_maps/test/map/or_map_prune_test.gleam
@@ -33,8 +33,8 @@ pub fn prune_with_unstable_remove_preserves_future_merge_value_test() {
     or_map.new(rid("B"), GCounterSpec)
     |> or_map.update("x", fn(c) { inc(c, 99) })
 
-  let merged_unpruned = or_map.merge(removed, concurrent)
-  let merged_pruned = or_map.merge(pruned, concurrent)
+  let assert Ok(merged_unpruned) = or_map.merge(removed, concurrent)
+  let assert Ok(merged_pruned) = or_map.merge(pruned, concurrent)
 
   or_map.keys(merged_pruned)
   |> set.from_list
@@ -166,7 +166,7 @@ pub fn prune_after_multi_replica_merge_test() {
     |> or_map.update("shared", fn(c) { inc(c, 7) })
     |> or_map.update("b_only", fn(c) { inc(c, 1) })
 
-  let merged = or_map.merge(map_a, map_b)
+  let assert Ok(merged) = or_map.merge(map_a, map_b)
   let merged = or_map.remove(merged, "b_only")
 
   let stable =
@@ -198,7 +198,7 @@ pub fn merge_after_noop_prune_preserves_removed_value_test() {
     or_map.new(rid("B"), GCounterSpec)
     |> or_map.update("x", fn(c) { inc(c, 99) })
 
-  let merged = or_map.merge(map_a, map_b)
+  let assert Ok(merged) = or_map.merge(map_a, map_b)
 
   case or_map.get(merged, "x") {
     Ok(CrdtGCounter(counter)) ->

--- a/packages/lattice_maps/test/map/or_map_test.gleam
+++ b/packages/lattice_maps/test/map/or_map_test.gleam
@@ -215,7 +215,7 @@ pub fn merge_disjoint_keys_test() {
   let map_a = or_map.update(map_a, "x", fn(c) { c })
   let map_b = or_map.new(rid("B"), GCounterSpec)
   let map_b = or_map.update(map_b, "y", fn(c) { c })
-  let merged = or_map.merge(map_a, map_b)
+  let assert Ok(merged) = or_map.merge(map_a, map_b)
   or_map.keys(merged)
   |> set.from_list
   |> expect.to_equal(set.from_list(["x", "y"]))
@@ -238,7 +238,7 @@ pub fn merge_nested_values_combined_test() {
         _ -> c
       }
     })
-  let merged = or_map.merge(map_a, map_b)
+  let assert Ok(merged) = or_map.merge(map_a, map_b)
   case or_map.get(merged, "score") {
     Ok(CrdtGCounter(counter)) -> g_counter.value(counter) |> expect.to_equal(10)
     _ -> expect.to_be_true(False)
@@ -254,7 +254,7 @@ pub fn merge_preserves_active_keys_from_both_sides_test() {
   let map_b =
     or_map.update(map_b, "beta", fn(c) { c })
     |> or_map.update("gamma", fn(c) { c })
-  let merged = or_map.merge(map_a, map_b)
+  let assert Ok(merged) = or_map.merge(map_a, map_b)
   or_map.keys(merged)
   |> set.from_list
   |> expect.to_equal(set.from_list(["alpha", "beta", "gamma"]))
@@ -275,7 +275,7 @@ pub fn concurrent_update_wins_over_remove_test() {
     })
 
   // 2. B syncs with A then removes "x"
-  let map_b = or_map.merge(or_map.new(rid("B"), GCounterSpec), map_a)
+  let assert Ok(map_b) = or_map.merge(or_map.new(rid("B"), GCounterSpec), map_a)
   let map_b = or_map.remove(map_b, "x")
 
   // 3. A concurrently updates "x" again (new tag not seen by B's remove)
@@ -288,7 +288,7 @@ pub fn concurrent_update_wins_over_remove_test() {
     })
 
   // 4. Merge: A's concurrent update should win (add-wins from OR-Set)
-  let merged = or_map.merge(map_a, map_b)
+  let assert Ok(merged) = or_map.merge(map_a, map_b)
 
   // "x" should still be present
   case or_map.get(merged, "x") {
@@ -308,7 +308,7 @@ pub fn merge_add_wins_keys_in_or_set_test() {
       }
     })
 
-  let map_b = or_map.merge(or_map.new(rid("B"), GCounterSpec), map_a)
+  let assert Ok(map_b) = or_map.merge(or_map.new(rid("B"), GCounterSpec), map_a)
   let map_b = or_map.remove(map_b, "x")
 
   let map_a =
@@ -319,7 +319,7 @@ pub fn merge_add_wins_keys_in_or_set_test() {
       }
     })
 
-  let merged = or_map.merge(map_a, map_b)
+  let assert Ok(merged) = or_map.merge(map_a, map_b)
 
   // Use keys() to check "x" is present (active in OR-Set)
   or_map.keys(merged)
@@ -342,8 +342,11 @@ pub fn merge_rejects_maps_with_different_specs_test() {
   let counters = or_map.new(rid("A"), GCounterSpec)
   let sets = or_map.new(rid("B"), GSetSpec)
 
-  or_map.merge(counters, sets)
-  |> expect.to_equal(counters)
+  case or_map.merge(counters, sets) {
+    Error(crdt.TypeMismatch(expected: "g_counter", found: "g_set")) ->
+      expect.to_be_true(True)
+    _ -> expect.to_be_true(False)
+  }
 }
 
 // --- keys() via public API ---

--- a/packages/lattice_maps/test/property/advanced_property_test.gleam
+++ b/packages/lattice_maps/test/property/advanced_property_test.gleam
@@ -36,7 +36,8 @@ pub fn or_map_bottom_identity__test() {
     let spec = crdt.GCounterSpec
     let m = or_map.new(rid("A"), spec) |> or_map.update("key", fn(c) { c })
     let bottom = or_map.new(rid("B"), spec)
-    set.from_list(or_map.keys(or_map.merge(m, bottom)))
+    let assert Ok(merged) = or_map.merge(m, bottom)
+    set.from_list(or_map.keys(merged))
     |> expect.to_equal(set.from_list(or_map.keys(m)))
     Nil
   })

--- a/packages/lattice_maps/test/property/map_property_test.gleam
+++ b/packages/lattice_maps/test/property/map_property_test.gleam
@@ -95,8 +95,10 @@ pub fn or_map_commutativity__test() {
       let map_b =
         or_map.new(rid("B"), crdt.GCounterSpec)
         |> or_map.update("x", increment_g_counter(_, b))
-      set.from_list(or_map.keys(or_map.merge(map_a, map_b)))
-      |> expect.to_equal(set.from_list(or_map.keys(or_map.merge(map_b, map_a))))
+      let assert Ok(merged_ab) = or_map.merge(map_a, map_b)
+      let assert Ok(merged_ba) = or_map.merge(map_b, map_a)
+      set.from_list(or_map.keys(merged_ab))
+      |> expect.to_equal(set.from_list(or_map.keys(merged_ba)))
       Nil
     },
   )
@@ -107,10 +109,11 @@ pub fn or_map_idempotency__test() {
     let map =
       or_map.new(rid("A"), crdt.GCounterSpec)
       |> or_map.update("x", increment_g_counter(_, a))
-    set.from_list(or_map.keys(or_map.merge(map, map)))
+    let assert Ok(merged) = or_map.merge(map, map)
+    set.from_list(or_map.keys(merged))
     |> expect.to_equal(set.from_list(or_map.keys(map)))
 
-    or_map.get(or_map.merge(map, map), "x")
+    or_map.get(merged, "x")
     |> expect.to_equal(or_map.get(map, "x"))
     Nil
   })
@@ -137,8 +140,10 @@ pub fn or_map_associativity__test() {
         or_map.new(rid("C"), crdt.GCounterSpec)
         |> or_map.update("x", increment_g_counter(_, c))
 
-      let merged1 = or_map.merge(or_map.merge(map_a, map_b), map_c)
-      let merged2 = or_map.merge(map_a, or_map.merge(map_b, map_c))
+      let assert Ok(ab) = or_map.merge(map_a, map_b)
+      let assert Ok(merged1) = or_map.merge(ab, map_c)
+      let assert Ok(bc) = or_map.merge(map_b, map_c)
+      let assert Ok(merged2) = or_map.merge(map_a, bc)
 
       set.from_list(or_map.keys(merged1))
       |> expect.to_equal(set.from_list(or_map.keys(merged2)))


### PR DESCRIPTION
## Summary

- **`crdt.merge`** now returns `Result(Crdt, MergeError)` instead of `Crdt`. Type mismatches return `Error(TypeMismatch(expected: "g_counter", found: "g_set"))` instead of silently returning the first argument.
- **`or_map.merge`** now returns `Result(ORMap, MergeError)` instead of `ORMap`. Spec mismatches between maps return the same error type. Internal per-key `crdt.merge` errors fall back to a default CRDT value.
- Adds `MergeError` type with `TypeMismatch(expected: String, found: String)` variant and `crdt.type_name/1` helper for getting human-readable type names.

Closes #25