### PR TITLE
ci: remove deprecated `install-just` input from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
     uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@07dae2969549e29a24a5fa49311795efff2ed66d # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
     with:
       cache: true
-      install-just: true
       run-deps: true
       test: true
 
@@ -42,7 +41,6 @@ jobs:
     uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@07dae2969549e29a24a5fa49311795efff2ed66d # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main
     with:
       cache: true
-      install-just: true
       run-deps: true
       test-js: true
 


### PR DESCRIPTION
## Summary

- Removes the deprecated `install-just: true` input from the `test` and `test-js` jobs in `ci.yml`
- The upstream reusable workflow (`tylerbutler/actions#27`) replaced `install-just` with a generic `tools` input that defaults to `just`, so behavior is unchanged

Closes #35