### PR TITLE
fix(release): add missing changie v1.0.0 history for lattice_crdt

### DIFF
--- a/.changes/lattice_crdt/v1.0.0.md
+++ b/.changes/lattice_crdt/v1.0.0.md
@@ -1,10 +1,3 @@
-# Changelog
-
-All notable changes to this project will be documented in this file.
-
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
 ## v1.0.0 - 2026-03-06
 
 


### PR DESCRIPTION
## Summary

- `lattice_crdt` v1.0.0 was published to Hex.pm on 2026-03-07 (pre-monorepo split), but changie had no version history for the `lattice_crdt` project — `.changes/lattice_crdt/` was empty
- Without version history, `changie batch auto` computed the next release as v1.0.0 (major bump from 0.0.0), colliding with the existing Hex publish
- Adds `.changes/lattice_crdt/v1.0.0.md` with the original release changelog so changie correctly bumps to v2.0.0
- Backfills the v1.0.0 entry in `packages/lattice_crdt/CHANGELOG.md`