### PR TITLE
fix(ci): use upstream workspace-file input for auto-tag workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -9,21 +9,10 @@ permissions:
   contents: write
 
 jobs:
-  workspace:
-    runs-on: ubuntu-latest
-    outputs:
-      projects: ${{ steps.ws.outputs.projects }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
-      - name: Read workspace
-        id: ws
-        uses: tylerbutler/actions/read-gleam-workspace@1b043450f1919503d6c23e3ada9fc7aaa4e2a99b # ratchet:tylerbutler/actions/read-gleam-workspace@main
-
   auto-tag:
-    needs: workspace
-    uses: tylerbutler/actions/.github/workflows/auto-tag.yml@1b043450f1919503d6c23e3ada9fc7aaa4e2a99b # ratchet:tylerbutler/actions/.github/workflows/auto-tag.yml@main
+    uses: tylerbutler/actions/.github/workflows/auto-tag.yml@4d7b8407d2c23fd22c750af2504940b13bdc3ee5 # ratchet:tylerbutler/actions/.github/workflows/auto-tag.yml@main
     with:
-      projects: ${{ needs.workspace.outputs.projects }}
+      workspace-file: workspace.toml
       create-release: true
     secrets:
       app-id: ${{ secrets.RELEASE_APP_ID }}


### PR DESCRIPTION
## Summary

- Replace broken two-job pattern with single reusable workflow call using new `workspace-file` input from tylerbutler/actions#29
- Pin to upstream commit `4d7b840` which includes the `workspace-file` support

## Problem

The `auto-tag.yml` workflow has **never worked** since the monorepo split (all 10 runs fail). The mixed regular+reusable job pattern — a `workspace` job feeding `projects` to the reusable `auto-tag` workflow via `needs` — causes GitHub Actions to fail resolving the reusable workflow reference entirely (0 jobs, empty `referenced_workflows`).

## Test plan

- [ ] CI passes on this PR
- [ ] Merge a release PR and verify auto-tag creates tags successfully