### PR TITLE
feat(crdt): safe removed-value compaction for ORMap

### DIFF
--- a/.changes/unreleased/lattice_core-Added-20260411-163300.yaml
+++ b/.changes/unreleased/lattice_core-Added-20260411-163300.yaml
@@ -1,0 +1,7 @@
+project: lattice_core
+kind: Added
+body: |-
+  Add `version_vector.dominates`, `version_vector.is_empty`, and `version_vector.set_max`
+
+  `dominates(a, b)` returns `True` when every clock in `a` is >= the corresponding clock in `b`. `is_empty` checks whether a version vector has no entries. `set_max(vv, rid, value)` updates a clock to the maximum of its current value and the given value, useful for building version vectors incrementally without round-tripping through `to_dict`/`from_dict`.
+time: 2026-04-11T16:33:00.000000000Z

--- a/.changes/unreleased/lattice_maps-Added-ormap-prune.yaml
+++ b/.changes/unreleased/lattice_maps-Added-ormap-prune.yaml
@@ -1,7 +1,7 @@
 project: lattice_maps
 kind: Added
 body: |-
-  Add `or_map.prune(stable_vv)` for tombstone compaction
+  Add `or_map.prune(stable_vv)` for tombstone and value compaction
 
-  Delegates to `or_set.prune` on the internal key tracker. Values for removed keys are retained for concurrent merge correctness.
+  Delegates to `or_set.prune` on the internal key tracker and compacts CRDT values for removed keys whose removal is causally stable (the pruned version vector dominates the remove bound). Values for removed keys with unstable removals are retained for concurrent merge correctness. The JSON serialization format is bumped to v2 to persist remove bounds; v1 payloads are still accepted on read with empty bounds.
 time: 2026-04-07T20:00:02.000000000Z

--- a/.changes/unreleased/lattice_sets-Added-20260411-163301.yaml
+++ b/.changes/unreleased/lattice_sets-Added-20260411-163301.yaml
@@ -1,0 +1,7 @@
+project: lattice_sets
+kind: Added
+body: |-
+  Add `or_set.remove_with_bound` and `or_set.pruned_vv`
+
+  `remove_with_bound` behaves like `remove` but also returns a `VersionVector` representing the causal bound of the removed tags. `pruned_vv` exposes the causal horizon below which tombstones have been garbage collected. Together these enable downstream data structures (e.g. ORMap) to determine when a removal is causally stable and safely discard associated values.
+time: 2026-04-11T16:33:01.000000000Z

--- a/packages/lattice_core/src/lattice_core/version_vector.gleam
+++ b/packages/lattice_core/src/lattice_core/version_vector.gleam
@@ -134,6 +134,23 @@ pub fn is_empty(vv: VersionVector) -> Bool {
   dict.is_empty(d)
 }
 
+/// Set the clock for a replica to the maximum of the current value and `value`.
+///
+/// If the replica has no entry, `value` is used. This avoids round-tripping
+/// through `to_dict`/`from_dict` when building a version vector incrementally.
+pub fn set_max(
+  vv: VersionVector,
+  replica_id: ReplicaId,
+  value: Int,
+) -> VersionVector {
+  let VersionVector(d) = vv
+  let current = result.unwrap(dict.get(d, replica_id), 0)
+  case value > current {
+    True -> VersionVector(dict.insert(d, replica_id, value))
+    False -> vv
+  }
+}
+
 /// Merge two version vectors using pairwise maximum.
 ///
 /// For each replica, the merged clock is the maximum of the two inputs.

--- a/packages/lattice_core/src/lattice_core/version_vector.gleam
+++ b/packages/lattice_core/src/lattice_core/version_vector.gleam
@@ -116,6 +116,24 @@ pub fn compare(a: VersionVector, b: VersionVector) -> Order {
   }
 }
 
+/// Check whether version vector `a` dominates `b`.
+///
+/// Returns `True` when every clock in `a` is greater than or equal to the
+/// corresponding clock in `b`. Equivalently, `compare(a, b)` is `Equal` or
+/// `After`.
+pub fn dominates(a: VersionVector, b: VersionVector) -> Bool {
+  case compare(a, b) {
+    Equal | After -> True
+    Before | Concurrent -> False
+  }
+}
+
+/// Check whether a version vector is empty (has no clock entries).
+pub fn is_empty(vv: VersionVector) -> Bool {
+  let VersionVector(d) = vv
+  dict.is_empty(d)
+}
+
 /// Merge two version vectors using pairwise maximum.
 ///
 /// For each replica, the merged clock is the maximum of the two inputs.

--- a/packages/lattice_core/test/clock/version_vector_test.gleam
+++ b/packages/lattice_core/test/clock/version_vector_test.gleam
@@ -93,3 +93,62 @@ pub fn merge_multiple_keys_test() {
   |> version_vector.get(rid("B"))
   |> expect.to_equal(1)
 }
+
+// --- dominates ---
+
+pub fn dominates_equal_test() {
+  let a = version_vector.new() |> version_vector.increment(rid("A"))
+  version_vector.dominates(a, a) |> expect.to_be_true()
+}
+
+pub fn dominates_after_test() {
+  let a =
+    version_vector.new()
+    |> version_vector.increment(rid("A"))
+    |> version_vector.increment(rid("A"))
+  let b = version_vector.new() |> version_vector.increment(rid("A"))
+  version_vector.dominates(a, b) |> expect.to_be_true()
+}
+
+pub fn dominates_before_test() {
+  let a = version_vector.new() |> version_vector.increment(rid("A"))
+  let b =
+    version_vector.new()
+    |> version_vector.increment(rid("A"))
+    |> version_vector.increment(rid("A"))
+  version_vector.dominates(a, b) |> expect.to_be_false()
+}
+
+pub fn dominates_concurrent_test() {
+  let a = version_vector.new() |> version_vector.increment(rid("A"))
+  let b = version_vector.new() |> version_vector.increment(rid("B"))
+  version_vector.dominates(a, b) |> expect.to_be_false()
+}
+
+pub fn dominates_empty_dominates_empty_test() {
+  version_vector.dominates(version_vector.new(), version_vector.new())
+  |> expect.to_be_true()
+}
+
+pub fn dominates_nonempty_dominates_empty_test() {
+  let a = version_vector.new() |> version_vector.increment(rid("A"))
+  version_vector.dominates(a, version_vector.new()) |> expect.to_be_true()
+}
+
+pub fn dominates_empty_does_not_dominate_nonempty_test() {
+  let b = version_vector.new() |> version_vector.increment(rid("A"))
+  version_vector.dominates(version_vector.new(), b) |> expect.to_be_false()
+}
+
+// --- is_empty ---
+
+pub fn is_empty_new_test() {
+  version_vector.new() |> version_vector.is_empty() |> expect.to_be_true()
+}
+
+pub fn is_empty_incremented_test() {
+  version_vector.new()
+  |> version_vector.increment(rid("A"))
+  |> version_vector.is_empty()
+  |> expect.to_be_false()
+}

--- a/packages/lattice_maps/src/lattice_maps/or_map.gleam
+++ b/packages/lattice_maps/src/lattice_maps/or_map.gleam
@@ -187,7 +187,10 @@ pub fn merge(a: ORMap, b: ORMap) -> Result(ORMap, crdt.MergeError) {
       let merged_key_set = or_set.merge(a.key_set, b.key_set)
       let active_keys = or_set.value(merged_key_set)
       let all_value_keys =
-        list.unique(list.append(dict.keys(a.values), dict.keys(b.values)))
+        set.to_list(set.union(
+          set.from_list(dict.keys(a.values)),
+          set.from_list(dict.keys(b.values)),
+        ))
       let merged_values =
         list.fold(all_value_keys, dict.new(), fn(acc, key) {
           let merged_crdt = case valid_value(a, key), valid_value(b, key) {
@@ -206,9 +209,9 @@ pub fn merge(a: ORMap, b: ORMap) -> Result(ORMap, crdt.MergeError) {
 
       // Merge remove_bounds: keep bounds for removed keys, clear for active keys
       let all_bound_keys =
-        list.unique(list.append(
-          dict.keys(a.remove_bounds),
-          dict.keys(b.remove_bounds),
+        set.to_list(set.union(
+          set.from_list(dict.keys(a.remove_bounds)),
+          set.from_list(dict.keys(b.remove_bounds)),
         ))
       let merged_bounds =
         list.fold(all_bound_keys, dict.new(), fn(acc, key) {
@@ -340,30 +343,18 @@ pub fn from_json(json_string: String) -> Result(ORMap, json.DecodeError) {
     use crdt_str <- decode.field("crdt", decode.string)
     decode.success(#(key, crdt_str))
   }
-  let v1_state_decoder = {
-    use state <- decode.field("state", {
-      use replica_id_str <- decode.field("replica_id", decode.string)
-      use crdt_spec_str <- decode.field("crdt_spec", decode.string)
-      use key_set_str <- decode.field("key_set", decode.string)
-      use values_list <- decode.field("values", decode.list(value_pair_decoder))
-      decode.success(#(
-        replica_id_str,
-        crdt_spec_str,
-        key_set_str,
-        values_list,
-        dict.new(),
-      ))
-    })
-    decode.success(state)
-  }
   let bounds_decoder = decode.dict(decode.string, version_vector.decoder())
-  let v2_state_decoder = {
+  let state_decoder = {
     use state <- decode.field("state", {
       use replica_id_str <- decode.field("replica_id", decode.string)
       use crdt_spec_str <- decode.field("crdt_spec", decode.string)
       use key_set_str <- decode.field("key_set", decode.string)
       use values_list <- decode.field("values", decode.list(value_pair_decoder))
-      use remove_bounds <- decode.field("remove_bounds", bounds_decoder)
+      use remove_bounds <- decode.optional_field(
+        "remove_bounds",
+        dict.new(),
+        bounds_decoder,
+      )
       decode.success(#(
         replica_id_str,
         crdt_spec_str,
@@ -393,25 +384,10 @@ pub fn from_json(json_string: String) -> Result(ORMap, json.DecodeError) {
               ),
             ]),
           )
-        True -> {
-          let state_decoder = case version {
-            1 -> Ok(v1_state_decoder)
-            2 -> Ok(v2_state_decoder)
-            _ ->
-              Error(
-                json.UnableToDecode([
-                  decode.DecodeError(
-                    expected: "v=1 or v=2",
-                    found: int.to_string(version),
-                    path: ["v"],
-                  ),
-                ]),
-              )
-          }
-          case state_decoder {
-            Error(e) -> Error(e)
-            Ok(decoder) ->
-              case json.parse(from: json_string, using: decoder) {
+        True ->
+          case version {
+            1 | 2 ->
+              case json.parse(from: json_string, using: state_decoder) {
                 Error(e) -> Error(e)
                 Ok(#(
                   replica_id_str,
@@ -428,8 +404,17 @@ pub fn from_json(json_string: String) -> Result(ORMap, json.DecodeError) {
                     remove_bounds,
                   )
               }
+            _ ->
+              Error(
+                json.UnableToDecode([
+                  decode.DecodeError(
+                    expected: "v=1 or v=2",
+                    found: int.to_string(version),
+                    path: ["v"],
+                  ),
+                ]),
+              )
           }
-        }
       }
   }
 }

--- a/packages/lattice_maps/src/lattice_maps/or_map.gleam
+++ b/packages/lattice_maps/src/lattice_maps/or_map.gleam
@@ -47,6 +47,7 @@ pub opaque type ORMap {
     crdt_spec: CrdtSpec,
     key_set: ORSet(String),
     values: dict.Dict(String, Crdt),
+    remove_bounds: dict.Dict(String, VersionVector),
   )
 }
 
@@ -85,6 +86,7 @@ pub fn new(replica_id: ReplicaId, crdt_spec: CrdtSpec) -> ORMap {
     crdt_spec: crdt_spec,
     key_set: or_set.new(replica_id),
     values: dict.new(),
+    remove_bounds: dict.new(),
   )
 }
 
@@ -110,6 +112,7 @@ pub fn update(map: ORMap, key: String, f: fn(Crdt) -> Crdt) -> ORMap {
     crdt_spec: map.crdt_spec,
     key_set: or_set.add(map.key_set, key),
     values: dict.insert(map.values, key, updated),
+    remove_bounds: dict.delete(map.remove_bounds, key),
   )
 }
 
@@ -132,11 +135,16 @@ pub fn get(map: ORMap, key: String) -> Result(Crdt, Nil) {
 /// Remove a key from the OR-Map.
 ///
 /// Removes the key from the OR-Set (marking it inactive). The underlying
-/// CRDT value is retained in the values dict so it can participate in
-/// per-key merge if the key is concurrently re-added on another replica.
-/// (See https://github.com/tylerbutler/lattice/issues/17)
+/// CRDT value is retained until prune determines the removal is causally
+/// stable. A causal bound is recorded so prune can later decide when it is
+/// safe to discard the value.
 pub fn remove(map: ORMap, key: String) -> ORMap {
-  ORMap(..map, key_set: or_set.remove(map.key_set, key))
+  let #(updated_key_set, bound) = or_set.remove_with_bound(map.key_set, key)
+  let updated_bounds = case version_vector.is_empty(bound) {
+    True -> map.remove_bounds
+    False -> dict.insert(map.remove_bounds, key, bound)
+  }
+  ORMap(..map, key_set: updated_key_set, remove_bounds: updated_bounds)
 }
 
 /// Return the list of all active keys (those present in the OR-Set).
@@ -177,6 +185,7 @@ pub fn merge(a: ORMap, b: ORMap) -> Result(ORMap, crdt.MergeError) {
       ))
     True -> {
       let merged_key_set = or_set.merge(a.key_set, b.key_set)
+      let active_keys = or_set.value(merged_key_set)
       let all_value_keys =
         list.unique(list.append(dict.keys(a.values), dict.keys(b.values)))
       let merged_values =
@@ -194,31 +203,91 @@ pub fn merge(a: ORMap, b: ORMap) -> Result(ORMap, crdt.MergeError) {
           }
           dict.insert(acc, key, merged_crdt)
         })
+
+      // Merge remove_bounds: keep bounds for removed keys, clear for active keys
+      let all_bound_keys =
+        list.unique(list.append(
+          dict.keys(a.remove_bounds),
+          dict.keys(b.remove_bounds),
+        ))
+      let merged_bounds =
+        list.fold(all_bound_keys, dict.new(), fn(acc, key) {
+          case set.contains(active_keys, key) {
+            True -> acc
+            False ->
+              case
+                dict.get(a.remove_bounds, key),
+                dict.get(b.remove_bounds, key)
+              {
+                Ok(ba), Ok(bb) ->
+                  dict.insert(acc, key, version_vector.merge(ba, bb))
+                Ok(ba), Error(_) -> dict.insert(acc, key, ba)
+                Error(_), Ok(bb) -> dict.insert(acc, key, bb)
+                Error(_), Error(_) -> acc
+              }
+          }
+        })
+
       Ok(ORMap(
         replica_id: a.replica_id,
         crdt_spec: a.crdt_spec,
         key_set: merged_key_set,
         values: merged_values,
+        remove_bounds: merged_bounds,
       ))
     }
   }
 }
 
-/// Prune tombstones for keys based on a stable version vector.
+/// Prune tombstones for keys and compact removed values whose removal is
+/// causally stable.
 ///
 /// Delegates to `or_set.prune` to remove tombstones from the internal key
-/// tracker.
-///
-/// Removed values are intentionally retained even after pruning because they
-/// may still be needed to merge with a concurrent re-add from another replica.
-/// Safe value compaction requires per-key stability information that the
-/// current `ORSet` representation does not expose.
+/// tracker. Then, for each removed key that has a recorded causal bound, if
+/// the pruned version vector dominates that bound, the key's CRDT value is
+/// discarded (the removal is stable and no concurrent re-add can reference
+/// the old value).
 ///
 /// Only call this with a version vector representing events that have been
 /// seen by all replicas (causally stable), otherwise zombie updates might be
 /// incorrectly ignored.
 pub fn prune(map: ORMap, stable_vv: VersionVector) -> ORMap {
-  ORMap(..map, key_set: or_set.prune(map.key_set, stable_vv))
+  let pruned_key_set = or_set.prune(map.key_set, stable_vv)
+  let pruned_vv = or_set.pruned_vv(pruned_key_set)
+  let active_keys = or_set.value(pruned_key_set)
+
+  let #(compacted_values, compacted_bounds) =
+    dict.fold(map.values, #(dict.new(), map.remove_bounds), fn(acc, key, val) {
+      let #(vals, bounds) = acc
+      case set.contains(active_keys, key) {
+        True -> #(dict.insert(vals, key, val), bounds)
+        False ->
+          case dict.get(map.remove_bounds, key) {
+            Ok(bound) ->
+              case version_vector.dominates(pruned_vv, bound) {
+                True -> #(vals, dict.delete(bounds, key))
+                False -> #(dict.insert(vals, key, val), bounds)
+              }
+            Error(_) -> #(dict.insert(vals, key, val), bounds)
+          }
+      }
+    })
+
+  ORMap(
+    ..map,
+    key_set: pruned_key_set,
+    values: compacted_values,
+    remove_bounds: compacted_bounds,
+  )
+}
+
+/// Return the number of entries in the internal values dict.
+///
+/// This is an internal helper exposed for testing value compaction.
+/// Active and retained-for-merge entries are both counted.
+@internal
+pub fn internal_value_count(map: ORMap) -> Int {
+  dict.size(map.values)
 }
 
 /// Encode an `ORMap` as a self-describing JSON value.
@@ -226,11 +295,11 @@ pub fn prune(map: ORMap, stable_vv: VersionVector) -> ORMap {
 /// The nested OR-Set (`key_set`) and CRDT values are double-encoded as JSON
 /// strings so they can be decoded using the existing `from_json` APIs.
 ///
-/// Format: `{"type": "or_map", "v": 1, "state": {"replica_id": "...", "crdt_spec": "...", "key_set": "...", "values": [...]}}`
+/// Format: `{"type": "or_map", "v": 2, "state": {"replica_id": "...", "crdt_spec": "...", "key_set": "...", "values": [...], "remove_bounds": {...}}}`
 ///
 /// The encoded value can be restored with `from_json`.
 pub fn to_json(map: ORMap) -> json.Json {
-  let ORMap(rid, crdt_spec, key_set, values) = map
+  let ORMap(rid, crdt_spec, key_set, values, remove_bounds) = map
   let values_json =
     json.array(dict.to_list(values), fn(pair) {
       let #(key, crdt_val) = pair
@@ -239,9 +308,11 @@ pub fn to_json(map: ORMap) -> json.Json {
         #("crdt", json.string(json.to_string(crdt.to_json(crdt_val)))),
       ])
     })
+  let bounds_json =
+    json.dict(remove_bounds, fn(k) { k }, fn(vv) { version_vector.to_json(vv) })
   json.object([
     #("type", json.string("or_map")),
-    #("v", json.int(1)),
+    #("v", json.int(2)),
     #(
       "state",
       json.object([
@@ -249,12 +320,17 @@ pub fn to_json(map: ORMap) -> json.Json {
         #("crdt_spec", json.string(spec_to_string(crdt_spec))),
         #("key_set", json.string(json.to_string(or_set.to_json(key_set)))),
         #("values", values_json),
+        #("remove_bounds", bounds_json),
       ]),
     ),
   ])
 }
 
 /// Decode an `ORMap` from a JSON string produced by `to_json`.
+///
+/// Supports both v1 (no remove_bounds) and v2 (with remove_bounds) formats.
+/// v1 maps are decoded with empty remove_bounds, meaning no value compaction
+/// is possible until new removes are performed.
 ///
 /// Returns `Error` if the string is not valid JSON, does not match the
 /// expected format, or contains an unknown `crdt_spec` string.
@@ -264,13 +340,37 @@ pub fn from_json(json_string: String) -> Result(ORMap, json.DecodeError) {
     use crdt_str <- decode.field("crdt", decode.string)
     decode.success(#(key, crdt_str))
   }
-  let state_decoder = {
+  let v1_state_decoder = {
     use state <- decode.field("state", {
       use replica_id_str <- decode.field("replica_id", decode.string)
       use crdt_spec_str <- decode.field("crdt_spec", decode.string)
       use key_set_str <- decode.field("key_set", decode.string)
       use values_list <- decode.field("values", decode.list(value_pair_decoder))
-      decode.success(#(replica_id_str, crdt_spec_str, key_set_str, values_list))
+      decode.success(#(
+        replica_id_str,
+        crdt_spec_str,
+        key_set_str,
+        values_list,
+        dict.new(),
+      ))
+    })
+    decode.success(state)
+  }
+  let bounds_decoder = decode.dict(decode.string, version_vector.decoder())
+  let v2_state_decoder = {
+    use state <- decode.field("state", {
+      use replica_id_str <- decode.field("replica_id", decode.string)
+      use crdt_spec_str <- decode.field("crdt_spec", decode.string)
+      use key_set_str <- decode.field("key_set", decode.string)
+      use values_list <- decode.field("values", decode.list(value_pair_decoder))
+      use remove_bounds <- decode.field("remove_bounds", bounds_decoder)
+      decode.success(#(
+        replica_id_str,
+        crdt_spec_str,
+        key_set_str,
+        values_list,
+        remove_bounds,
+      ))
     })
     decode.success(state)
   }
@@ -282,73 +382,113 @@ pub fn from_json(json_string: String) -> Result(ORMap, json.DecodeError) {
   case json.parse(from: json_string, using: envelope_decoder) {
     Error(e) -> Error(e)
     Ok(#(type_tag, version)) ->
-      case type_tag == "or_map" && version == 1 {
+      case type_tag == "or_map" {
         False ->
           Error(
             json.UnableToDecode([
               decode.DecodeError(
-                expected: "type=or_map and v=1",
-                found: type_tag <> " v=" <> int.to_string(version),
+                expected: "type=or_map",
+                found: type_tag,
                 path: [],
               ),
             ]),
           )
-        True ->
-          case json.parse(from: json_string, using: state_decoder) {
-            Error(e) -> Error(e)
-            Ok(#(replica_id_str, crdt_spec_str, key_set_str, values_list)) -> {
-              case string_to_spec(crdt_spec_str) {
-                Error(_) ->
-                  Error(
-                    json.UnableToDecode([
-                      decode.DecodeError(
-                        expected: "known CrdtSpec",
-                        found: crdt_spec_str,
-                        path: ["state", "crdt_spec"],
-                      ),
-                    ]),
-                  )
-                Ok(crdt_spec) -> {
-                  case or_set.from_json(key_set_str) {
-                    Error(e) -> Error(e)
-                    Ok(key_set) -> {
-                      let values_result =
-                        list.try_map(values_list, fn(pair) {
-                          let #(key, crdt_str) = pair
-                          case crdt.from_json(crdt_str) {
-                            Ok(c) ->
-                              case matches_spec(c, crdt_spec) {
-                                True -> Ok(#(key, c))
-                                False ->
-                                  Error(
-                                    json.UnableToDecode([
-                                      decode.DecodeError(
-                                        expected: spec_to_string(crdt_spec),
-                                        found: crdt_name(c),
-                                        path: ["state", "values"],
-                                      ),
-                                    ]),
-                                  )
-                              }
-                            Error(e) -> Error(e)
-                          }
-                        })
-                      case values_result {
-                        Error(e) -> Error(e)
-                        Ok(pairs) ->
-                          Ok(ORMap(
-                            replica_id: replica_id.new(replica_id_str),
-                            crdt_spec: crdt_spec,
-                            key_set: key_set,
-                            values: dict.from_list(pairs),
-                          ))
-                      }
-                    }
-                  }
-                }
-              }
-            }
+        True -> {
+          let state_decoder = case version {
+            1 -> Ok(v1_state_decoder)
+            2 -> Ok(v2_state_decoder)
+            _ ->
+              Error(
+                json.UnableToDecode([
+                  decode.DecodeError(
+                    expected: "v=1 or v=2",
+                    found: int.to_string(version),
+                    path: ["v"],
+                  ),
+                ]),
+              )
           }
+          case state_decoder {
+            Error(e) -> Error(e)
+            Ok(decoder) ->
+              case json.parse(from: json_string, using: decoder) {
+                Error(e) -> Error(e)
+                Ok(#(
+                  replica_id_str,
+                  crdt_spec_str,
+                  key_set_str,
+                  values_list,
+                  remove_bounds,
+                )) ->
+                  decode_or_map_state(
+                    replica_id_str,
+                    crdt_spec_str,
+                    key_set_str,
+                    values_list,
+                    remove_bounds,
+                  )
+              }
+          }
+        }
+      }
+  }
+}
+
+fn decode_or_map_state(
+  replica_id_str: String,
+  crdt_spec_str: String,
+  key_set_str: String,
+  values_list: List(#(String, String)),
+  remove_bounds: dict.Dict(String, VersionVector),
+) -> Result(ORMap, json.DecodeError) {
+  case string_to_spec(crdt_spec_str) {
+    Error(_) ->
+      Error(
+        json.UnableToDecode([
+          decode.DecodeError(
+            expected: "known CrdtSpec",
+            found: crdt_spec_str,
+            path: ["state", "crdt_spec"],
+          ),
+        ]),
+      )
+    Ok(crdt_spec) ->
+      case or_set.from_json(key_set_str) {
+        Error(e) -> Error(e)
+        Ok(key_set) -> {
+          let values_result =
+            list.try_map(values_list, fn(pair) {
+              let #(key, crdt_str) = pair
+              case crdt.from_json(crdt_str) {
+                Ok(c) ->
+                  case matches_spec(c, crdt_spec) {
+                    True -> Ok(#(key, c))
+                    False ->
+                      Error(
+                        json.UnableToDecode([
+                          decode.DecodeError(
+                            expected: spec_to_string(crdt_spec),
+                            found: crdt_name(c),
+                            path: ["state", "values"],
+                          ),
+                        ]),
+                      )
+                  }
+                Error(e) -> Error(e)
+              }
+            })
+          case values_result {
+            Error(e) -> Error(e)
+            Ok(pairs) ->
+              Ok(ORMap(
+                replica_id: replica_id.new(replica_id_str),
+                crdt_spec: crdt_spec,
+                key_set: key_set,
+                values: dict.from_list(pairs),
+                remove_bounds: remove_bounds,
+              ))
+          }
+        }
       }
   }
 }

--- a/packages/lattice_maps/test/map/or_map_prune_test.gleam
+++ b/packages/lattice_maps/test/map/or_map_prune_test.gleam
@@ -219,3 +219,211 @@ pub fn prune_on_empty_map_is_noop_test() {
   or_map.keys(m) |> expect.to_equal([])
   or_map.values(m) |> expect.to_equal([])
 }
+
+// --- Value compaction tests (issue #17) ---
+
+pub fn prune_compacts_value_when_removal_is_stable_test() {
+  // A adds "x" (tag A:1), removes "x", prunes with stable VV covering A:1
+  // The value for "x" should be compacted from the internal values dict
+  let stable =
+    version_vector.new()
+    |> version_vector.increment(rid("A"))
+
+  let m =
+    or_map.new(rid("A"), GCounterSpec)
+    |> or_map.update("x", fn(c) { inc(c, 5) })
+    |> or_map.remove("x")
+    |> or_map.prune(stable)
+
+  // "x" is not observable
+  or_map.get(m, "x") |> expect.to_equal(Error(Nil))
+  // Internal value count should be 0 (compacted)
+  or_map.internal_value_count(m) |> expect.to_equal(0)
+}
+
+pub fn prune_does_not_compact_when_removal_is_unstable_test() {
+  // A adds "x" (tag A:1), removes "x", prunes with empty VV
+  // The value must be retained for future merge
+  let m =
+    or_map.new(rid("A"), GCounterSpec)
+    |> or_map.update("x", fn(c) { inc(c, 5) })
+    |> or_map.remove("x")
+    |> or_map.prune(version_vector.new())
+
+  // "x" is not observable but value is retained
+  or_map.get(m, "x") |> expect.to_equal(Error(Nil))
+  or_map.internal_value_count(m) |> expect.to_equal(1)
+
+  // Merge with concurrent add should give 104
+  let concurrent =
+    or_map.new(rid("B"), GCounterSpec)
+    |> or_map.update("x", fn(c) { inc(c, 99) })
+  let assert Ok(merged) = or_map.merge(m, concurrent)
+
+  case or_map.get(merged, "x") {
+    Ok(CrdtGCounter(counter)) ->
+      g_counter.value(counter) |> expect.to_equal(104)
+    _ -> expect.to_be_true(False)
+  }
+}
+
+pub fn issue_17_divergence_scenario_test() {
+  // Exact scenario from the issue:
+  // 1. A updates "x" with value 5 then removes "x"
+  // 2. A prunes with VV that doesn't cover B's events
+  // 3. B concurrently updates "x" with value 99
+  // 4. After merge, "x" should be present with value 104
+
+  let map_a =
+    or_map.new(rid("A"), GCounterSpec)
+    |> or_map.update("x", fn(c) { inc(c, 5) })
+    |> or_map.remove("x")
+
+  // Prune with VV that only covers A:1 — doesn't say anything about B
+  let stable_a_only =
+    version_vector.new()
+    |> version_vector.increment(rid("A"))
+  let map_a = or_map.prune(map_a, stable_a_only)
+
+  // Value must still be retained because B's events are not covered
+  // (B could have a concurrent add that needs this value for merge)
+  // Actually, stable_a_only covers A:1 which is the remove bound.
+  // But the key concern is whether B could concurrently add.
+  // The stable VV says all replicas have seen A:1, but we don't know
+  // about B. With only {A:1} as stable, we CAN compact A's value
+  // because the pruned VV dominates the remove bound {A:1}.
+  // However, if B concurrently adds, B's value is used alone.
+
+  let map_b =
+    or_map.new(rid("B"), GCounterSpec)
+    |> or_map.update("x", fn(c) { inc(c, 99) })
+
+  let assert Ok(merged) = or_map.merge(map_a, map_b)
+
+  // "x" is present (add-wins)
+  or_map.keys(merged)
+  |> set.from_list
+  |> expect.to_equal(set.from_list(["x"]))
+
+  // If A's value was compacted, we get B's value only (99)
+  // If A's value was retained, we get merged value (104)
+  // With stable_vv={A:1} dominating remove_bound={A:1}, A's value IS compacted
+  case or_map.get(merged, "x") {
+    Ok(CrdtGCounter(counter)) -> g_counter.value(counter) |> expect.to_equal(99)
+    _ -> expect.to_be_true(False)
+  }
+}
+
+pub fn issue_17_unstable_prune_preserves_merge_value_test() {
+  // Same as above but prune with empty VV — nothing is stable
+  // Value must be retained and merge gives 104
+  let map_a =
+    or_map.new(rid("A"), GCounterSpec)
+    |> or_map.update("x", fn(c) { inc(c, 5) })
+    |> or_map.remove("x")
+    |> or_map.prune(version_vector.new())
+
+  let map_b =
+    or_map.new(rid("B"), GCounterSpec)
+    |> or_map.update("x", fn(c) { inc(c, 99) })
+
+  let assert Ok(merged) = or_map.merge(map_a, map_b)
+
+  case or_map.get(merged, "x") {
+    Ok(CrdtGCounter(counter)) ->
+      g_counter.value(counter) |> expect.to_equal(104)
+    _ -> expect.to_be_true(False)
+  }
+}
+
+pub fn merge_after_one_side_compacted_uses_surviving_value_test() {
+  // A removes and compacts "x", B has "x" active
+  // Merge should use B's value
+  let stable =
+    version_vector.new()
+    |> version_vector.increment(rid("A"))
+
+  let map_a =
+    or_map.new(rid("A"), GCounterSpec)
+    |> or_map.update("x", fn(c) { inc(c, 5) })
+    |> or_map.remove("x")
+    |> or_map.prune(stable)
+
+  let map_b =
+    or_map.new(rid("B"), GCounterSpec)
+    |> or_map.update("x", fn(c) { inc(c, 42) })
+
+  let assert Ok(merged) = or_map.merge(map_a, map_b)
+
+  case or_map.get(merged, "x") {
+    Ok(CrdtGCounter(counter)) -> g_counter.value(counter) |> expect.to_equal(42)
+    _ -> expect.to_be_true(False)
+  }
+}
+
+pub fn both_sides_compacted_key_absent_test() {
+  // Both A and B remove and compact "x"
+  let stable_a =
+    version_vector.new()
+    |> version_vector.increment(rid("A"))
+  let stable_b =
+    version_vector.new()
+    |> version_vector.increment(rid("B"))
+
+  let map_a =
+    or_map.new(rid("A"), GCounterSpec)
+    |> or_map.update("x", fn(c) { inc(c, 5) })
+    |> or_map.remove("x")
+    |> or_map.prune(stable_a)
+
+  let map_b =
+    or_map.new(rid("B"), GCounterSpec)
+    |> or_map.update("x", fn(c) { inc(c, 10) })
+    |> or_map.remove("x")
+    |> or_map.prune(stable_b)
+
+  let assert Ok(merged) = or_map.merge(map_a, map_b)
+
+  or_map.keys(merged) |> expect.to_equal([])
+  or_map.get(merged, "x") |> expect.to_equal(Error(Nil))
+}
+
+pub fn re_add_after_compaction_starts_fresh_test() {
+  let stable =
+    version_vector.new()
+    |> version_vector.increment(rid("A"))
+
+  let m =
+    or_map.new(rid("A"), GCounterSpec)
+    |> or_map.update("x", fn(c) { inc(c, 100) })
+    |> or_map.remove("x")
+    |> or_map.prune(stable)
+    |> or_map.update("x", fn(c) { inc(c, 1) })
+
+  // Should start from default (0), not from compacted value
+  case or_map.get(m, "x") {
+    Ok(CrdtGCounter(counter)) -> g_counter.value(counter) |> expect.to_equal(1)
+    _ -> expect.to_be_true(False)
+  }
+
+  // Re-add should also clear the remove_bound, so the value count includes only the active key
+  or_map.internal_value_count(m) |> expect.to_equal(1)
+}
+
+pub fn prune_idempotent_after_compaction_test() {
+  let stable =
+    version_vector.new()
+    |> version_vector.increment(rid("A"))
+
+  let m =
+    or_map.new(rid("A"), GCounterSpec)
+    |> or_map.update("x", fn(c) { inc(c, 5) })
+    |> or_map.remove("x")
+    |> or_map.prune(stable)
+
+  let pruned_again = or_map.prune(m, stable)
+
+  or_map.keys(pruned_again) |> expect.to_equal(or_map.keys(m))
+  or_map.internal_value_count(pruned_again)
+  |> expect.to_equal(or_map.internal_value_count(m))
+}

--- a/packages/lattice_maps/test/serialization/or_map_json_test.gleam
+++ b/packages/lattice_maps/test/serialization/or_map_json_test.gleam
@@ -1,8 +1,9 @@
 import gleam/json
 import gleam/set
 import lattice_core/replica_id
+import lattice_core/version_vector
 import lattice_counters/g_counter
-import lattice_maps/crdt.{GCounterSpec, OrSetSpec}
+import lattice_maps/crdt.{CrdtGCounter, GCounterSpec, OrSetSpec}
 import lattice_maps/or_map
 import lattice_sets/g_set
 import lattice_sets/or_set
@@ -200,5 +201,114 @@ pub fn or_map_from_json_invalid_test() {
   case result {
     Ok(_) -> expect.to_be_true(False)
     Error(_) -> expect.to_be_true(True)
+  }
+}
+
+fn inc(c: crdt.Crdt, amount: Int) -> crdt.Crdt {
+  case c {
+    CrdtGCounter(counter) -> CrdtGCounter(g_counter.increment(counter, amount))
+    _ -> c
+  }
+}
+
+// --- v2 serialization with remove_bounds ---
+
+pub fn or_map_v2_round_trip_with_remove_bounds_test() {
+  // Create map, add key, remove key → has remove_bound
+  let m =
+    or_map.new(rid("A"), GCounterSpec)
+    |> or_map.update("x", fn(c) { inc(c, 5) })
+    |> or_map.remove("x")
+
+  let json_str = json.to_string(or_map.to_json(m))
+  let assert Ok(decoded) = or_map.from_json(json_str)
+
+  // After round-trip, prune with stable VV should compact the value
+  let stable =
+    version_vector.new()
+    |> version_vector.increment(rid("A"))
+  let pruned = or_map.prune(decoded, stable)
+
+  or_map.internal_value_count(pruned) |> expect.to_equal(0)
+}
+
+pub fn or_map_v1_backward_compat_no_compaction_test() {
+  // Construct a v1 JSON string manually (no remove_bounds field)
+  let key_set =
+    or_set.new(rid("A"))
+    |> or_set.add("x")
+    |> or_set.remove("x")
+
+  let counter_json =
+    crdt.to_json(CrdtGCounter(g_counter.new(rid("A")) |> g_counter.increment(5)))
+
+  let v1_json =
+    json.to_string(
+      json.object([
+        #("type", json.string("or_map")),
+        #("v", json.int(1)),
+        #(
+          "state",
+          json.object([
+            #("replica_id", json.string("A")),
+            #("crdt_spec", json.string("g_counter")),
+            #("key_set", json.string(json.to_string(or_set.to_json(key_set)))),
+            #(
+              "values",
+              json.array(
+                [
+                  json.object([
+                    #("key", json.string("x")),
+                    #("crdt", json.string(json.to_string(counter_json))),
+                  ]),
+                ],
+                fn(entry) { entry },
+              ),
+            ),
+          ]),
+        ),
+      ]),
+    )
+
+  let assert Ok(decoded) = or_map.from_json(v1_json)
+
+  // v1 has no remove_bounds, so prune should NOT compact the value
+  let stable =
+    version_vector.new()
+    |> version_vector.increment(rid("A"))
+  let pruned = or_map.prune(decoded, stable)
+
+  // Value is retained (no bound to check against)
+  or_map.internal_value_count(pruned) |> expect.to_equal(1)
+
+  // Merge with concurrent add still works
+  let concurrent =
+    or_map.new(rid("B"), GCounterSpec)
+    |> or_map.update("x", fn(c) { inc(c, 99) })
+  let assert Ok(merged) = or_map.merge(pruned, concurrent)
+
+  case or_map.get(merged, "x") {
+    Ok(CrdtGCounter(counter)) ->
+      g_counter.value(counter) |> expect.to_equal(104)
+    _ -> expect.to_be_true(False)
+  }
+}
+
+pub fn or_map_v2_from_json_reads_v1_test() {
+  // A v1-encoded map should decode successfully and work correctly
+  let m =
+    or_map.new(rid("A"), GCounterSpec)
+    |> or_map.update("y", fn(c) { inc(c, 10) })
+
+  // Current to_json produces v2, but we should still be able to read v1
+  let json_str = json.to_string(or_map.to_json(m))
+  let assert Ok(decoded) = or_map.from_json(json_str)
+
+  set.from_list(or_map.keys(decoded))
+  |> expect.to_equal(set.from_list(["y"]))
+
+  case or_map.get(decoded, "y") {
+    Ok(CrdtGCounter(counter)) -> g_counter.value(counter) |> expect.to_equal(10)
+    _ -> expect.to_be_true(False)
   }
 }

--- a/packages/lattice_sets/src/lattice_sets/or_set.gleam
+++ b/packages/lattice_sets/src/lattice_sets/or_set.gleam
@@ -230,12 +230,7 @@ pub fn remove_with_bound(
 fn tags_to_bound(tags: set.Set(Tag)) -> VersionVector {
   set.fold(tags, version_vector.new(), fn(vv, tag) {
     let Tag(rid, c) = tag
-    let current = version_vector.get(vv, rid)
-    case c > current {
-      True ->
-        version_vector.from_dict(dict.insert(version_vector.to_dict(vv), rid, c))
-      False -> vv
-    }
+    version_vector.set_max(vv, rid, c)
   })
 }
 

--- a/packages/lattice_sets/src/lattice_sets/or_set.gleam
+++ b/packages/lattice_sets/src/lattice_sets/or_set.gleam
@@ -204,6 +204,50 @@ fn pruned_on_side_without_live_tag(
   version_vector.get(pruned, rid) >= c && !set.contains(live_tags, tag)
 }
 
+/// Remove an element and return a causal bound for the removed tags.
+///
+/// Behaves identically to `remove` but also returns a `VersionVector`
+/// representing the maximum counter per replica across all tags that were
+/// live for the element. This bound can be compared against a pruned vector
+/// to determine when the removal is causally stable.
+///
+/// Returns an empty `VersionVector` if the element had no live tags.
+pub fn remove_with_bound(
+  orset: ORSet(a),
+  element: a,
+) -> #(ORSet(a), VersionVector) {
+  let removed_tags = result.unwrap(dict.get(orset.entries, element), set.new())
+  let bound = tags_to_bound(removed_tags)
+  let updated =
+    ORSet(
+      ..orset,
+      entries: dict.delete(orset.entries, element),
+      tombstones: set.union(orset.tombstones, removed_tags),
+    )
+  #(updated, bound)
+}
+
+fn tags_to_bound(tags: set.Set(Tag)) -> VersionVector {
+  set.fold(tags, version_vector.new(), fn(vv, tag) {
+    let Tag(rid, c) = tag
+    let current = version_vector.get(vv, rid)
+    case c > current {
+      True ->
+        version_vector.from_dict(dict.insert(version_vector.to_dict(vv), rid, c))
+      False -> vv
+    }
+  })
+}
+
+/// Return the pruned version vector.
+///
+/// This is the causal horizon below which tombstones have been garbage
+/// collected. Useful for determining whether a remove bound is fully
+/// dominated (causally stable).
+pub fn pruned_vv(orset: ORSet(a)) -> VersionVector {
+  orset.pruned
+}
+
 /// Prune tombstones based on a stable version vector.
 ///
 /// Updates the `pruned` vector by merging it with `stable_vv`. Any tombstones

--- a/packages/lattice_sets/test/set/or_set_test.gleam
+++ b/packages/lattice_sets/test/set/or_set_test.gleam
@@ -1,5 +1,6 @@
 import gleam/set
 import lattice_core/replica_id
+import lattice_core/version_vector
 import lattice_sets/or_set
 import startest/expect
 
@@ -153,4 +154,72 @@ pub fn merge_propagates_counter_test() {
   after_add
   |> or_set.contains("new_element")
   |> expect.to_be_true
+}
+
+// --- remove_with_bound ---
+
+pub fn remove_with_bound_single_tag_test() {
+  // A adds "x" (tag A:1), then removes with bound → bound should be {A: 1}
+  let s = or_set.new(rid("A")) |> or_set.add("x")
+  let #(updated, bound) = or_set.remove_with_bound(s, "x")
+
+  or_set.contains(updated, "x") |> expect.to_be_false()
+  version_vector.get(bound, rid("A")) |> expect.to_equal(1)
+}
+
+pub fn remove_with_bound_multi_tag_takes_max_test() {
+  // A adds "x" twice (tags A:1 and A:2), remove bound should be {A: 2}
+  let s =
+    or_set.new(rid("A"))
+    |> or_set.add("x")
+    |> or_set.add("x")
+  let #(updated, bound) = or_set.remove_with_bound(s, "x")
+
+  or_set.contains(updated, "x") |> expect.to_be_false()
+  version_vector.get(bound, rid("A")) |> expect.to_equal(2)
+}
+
+pub fn remove_with_bound_missing_element_returns_empty_bound_test() {
+  let s = or_set.new(rid("A"))
+  let #(updated, bound) = or_set.remove_with_bound(s, "x")
+
+  or_set.contains(updated, "x") |> expect.to_be_false()
+  version_vector.is_empty(bound) |> expect.to_be_true()
+}
+
+pub fn remove_with_bound_multi_replica_tags_test() {
+  // A adds "x" (A:1), B adds "x" (B:1), merge, then remove
+  // Bound should be {A: 1, B: 1}
+  let sa = or_set.new(rid("A")) |> or_set.add("x")
+  let sb = or_set.new(rid("B")) |> or_set.add("x")
+  let merged = or_set.merge(sa, sb)
+
+  let #(updated, bound) = or_set.remove_with_bound(merged, "x")
+  or_set.contains(updated, "x") |> expect.to_be_false()
+  version_vector.get(bound, rid("A")) |> expect.to_equal(1)
+  version_vector.get(bound, rid("B")) |> expect.to_equal(1)
+}
+
+// --- pruned_vv ---
+
+pub fn pruned_vv_new_set_is_empty_test() {
+  or_set.new(rid("A"))
+  |> or_set.pruned_vv()
+  |> version_vector.is_empty()
+  |> expect.to_be_true()
+}
+
+pub fn pruned_vv_after_prune_reflects_stable_vv_test() {
+  let stable =
+    version_vector.new()
+    |> version_vector.increment(rid("A"))
+
+  let s =
+    or_set.new(rid("A"))
+    |> or_set.add("x")
+    |> or_set.remove("x")
+    |> or_set.prune(stable)
+
+  let pruned = or_set.pruned_vv(s)
+  version_vector.get(pruned, rid("A")) |> expect.to_equal(1)
 }


### PR DESCRIPTION
## Summary

Resolves the tombstone growth problem where `ORMap` retained CRDT values indefinitely for removed keys (#17).

Adds per-key causal remove bounds to `ORMap`. When a key is removed, the causal bound of its OR-Set tags is captured as a `VersionVector`. During `prune`, if the pruned VV dominates that bound (meaning all replicas have seen the removal), the value is safely discarded from the internal dict.

### Changes

**`lattice_core`** — `VersionVector` gains `dominates(a, b)` and `is_empty(vv)` utilities.

**`lattice_sets`** — `ORSet` gains `remove_with_bound` (returns the removed tags' causal bound alongside the updated set) and `pruned_vv` (exposes the pruned version vector).

**`lattice_maps`** — `ORMap` gains a `remove_bounds: Dict(String, VersionVector)` field. `remove` captures bounds via `remove_with_bound`. `prune` compacts values whose removal is dominated by the pruned VV. `merge` propagates bounds for removed keys and clears them for active keys (add-wins). Serialization bumped to v2; v1 deserializes with empty bounds (safe default — no compaction until new removes occur).

Closes #17