### PR TITLE
ci: use conventional commit format for release PR titles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
-          pr-title-template: 'release {version}'
+          pr-title-template: 'chore(release): {version}'
           projects: ${{ steps.ws.outputs.projects }}
           version-files: |
             ${{ steps.ws.outputs.version-files }}


### PR DESCRIPTION
## Summary
- Updates the `pr-title-template` in the changie-release workflow step from `release {version}` to `chore(release): {version}` so release PRs follow conventional commit format.

## Test plan
- [ ] Verify the release workflow creates PRs with the new title format on next changelog batch