### PR TITLE
fix: adjust changie heading levels for better changelog hierarchy

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -7,9 +7,9 @@ versionFooterPath: ""
 versionExt: md
 envPrefix: CHANGIE
 versionFormat: '## {{.Version}} - {{.Time.Format "2006-01-02"}}'
-kindFormat: '#### {{.Kind}}'
+kindFormat: '### {{.Kind}}'
 changeFormat: |-
-    ##### {{(splitn "\n" 2 .Body)._0}}
+    #### {{(splitn "\n" 2 .Body)._0}}
     {{with (splitn "\n" 2 .Body)._1 | default "" | trim}}
     {{.}}
     {{end}}


### PR DESCRIPTION
## Summary
- Promotes `kindFormat` heading from `####` (h4) to `###` (h3)
- Promotes `changeFormat` heading from `#####` (h5) to `####` (h4)
- Ensures changelog sections render with correct visual hierarchy under the `##` version header

## Test plan
- [ ] Verify existing changelogs still render correctly
- [ ] Run `just change` and confirm new entries use updated heading levels