### PR TITLE
docs: improve changelog entries for user-facing clarity

### DIFF
--- a/.changes/lattice_crdt/v1.0.0.md
+++ b/.changes/lattice_crdt/v1.0.0.md
@@ -1,28 +1,71 @@
 ## v1.0.0 - 2026-03-06
 
+Initial release of lattice — a [CRDT](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type) library for Gleam targeting both Erlang and JavaScript runtimes. Every type converges automatically when replicas merge, with no coordination required. See the [documentation](https://lattice.tylerbutler.com) for guides and API reference.
 
 #### Added
 
 ##### Counter types
 
-Grow-only counters (`g_counter`) and positive-negative counters (`pn_counter`) that automatically converge across replicas.
+Grow-only counters (`g_counter`) for monotonically increasing values, and positive-negative counters (`pn_counter`) that support both increment and decrement. Use `g_counter` when values only go up (e.g. event counts); use `pn_counter` when you need subtraction (e.g. inventory levels).
+
+```gleam
+let counter = g_counter.new("node-a") |> g_counter.increment(5)
+g_counter.value(counter)  // -> 5
+
+// Merge two replicas — values combine automatically
+let merged = g_counter.merge(counter_a, counter_b)
+```
 
 ##### Register types
 
-Last-writer-wins registers (`lww_register`) and multi-value registers (`mv_register`) for storing single values with conflict resolution.
+Last-writer-wins registers (`lww_register`) resolve conflicts by timestamp — the most recent write wins. Multi-value registers (`mv_register`) preserve all concurrent writes, letting your application decide how to resolve them.
+
+```gleam
+// LWW: latest timestamp wins
+let reg = lww_register.new("initial", 1, "node-a")
+let reg = lww_register.set(reg, "updated", 2)
+
+// MV: concurrent writes are all preserved
+let merged = mv_register.merge(reg_a, reg_b)
+mv_register.value(merged)  // -> ["value-a", "value-b"]
+```
 
 ##### Set types
 
-Grow-only sets (`g_set`), two-phase sets with remove-once semantics (`two_p_set`), and observed-remove sets (`or_set`) for managing collections across replicas.
+Three set types with different trade-offs:
+
+- **`g_set`** — Grow-only. Elements can be added but never removed. Simplest and most efficient.
+- **`two_p_set`** — Two-phase. Elements can be removed once, but a removed element can never be re-added.
+- **`or_set`** — Observed-remove. Elements can be freely added and removed. Concurrent add and remove of the same element resolves in favor of the add (add-wins semantics).
+
+```gleam
+let a = or_set.new("node-a") |> or_set.add("item")
+let b = or_set.new("node-b") |> or_set.add("item") |> or_set.remove("item")
+let merged = or_set.merge(a, b)
+or_set.contains(merged, "item")  // -> True (add wins)
+```
 
 ##### Map types
 
-Last-writer-wins maps (`lww_map`) and observed-remove maps (`or_map`) for key-value storage with automatic conflict resolution.
+Key-value maps with automatic conflict resolution:
+
+- **`lww_map`** — Last-writer-wins semantics per key, with timestamp-based conflict resolution. Supports `remove` with tombstones.
+- **`or_map`** — Observed-remove semantics with nested CRDT values. Each key holds a full CRDT (counter, register, set, etc.) that merges independently.
+
+```gleam
+let map = lww_map.new() |> lww_map.set("name", "Alice", 1)
+lww_map.get(map, "name")  // -> Ok("Alice")
+```
 
 ##### Causal context primitives
 
-Version vectors (`version_vector`) and dot contexts (`dot_context`) for tracking causality between replicas.
+Version vectors (`version_vector`) for tracking happened-before relationships between replicas, and dot contexts (`dot_context`) for fine-grained causal tracking used internally by `or_set` and `or_map`. You typically interact with version vectors directly when configuring advanced merge or pruning behavior.
 
 ##### JSON serialization
 
-All CRDT types include `to_json` and `from_json` functions for persisting and transmitting state between nodes.
+All types include `to_json` and `from_json` functions for persisting state and transmitting it between nodes.
+
+```gleam
+let json_str = g_counter.to_json(counter) |> json.to_string
+let assert Ok(restored) = g_counter.from_json(json_str)
+```

--- a/.changes/unreleased/lattice_core-Added-initial-api.yaml
+++ b/.changes/unreleased/lattice_core-Added-initial-api.yaml
@@ -1,0 +1,13 @@
+project: lattice_core
+kind: Added
+body: |-
+  Causal context primitives for lattice CRDTs
+
+  Provides the foundational building blocks used by other lattice packages:
+
+  - **`replica_id`** — Opaque `ReplicaId` type for type-safe identification of replicas. Create with `replica_id.new("node-a")`.
+  - **`version_vector`** — Tracks happened-before relationships between replicas. Supports `increment`, `merge`, `compare`, `dominates`, and `is_empty`. Compare returns `Before`, `After`, `Concurrent`, or `Equal`.
+  - **`dot_context`** — Fine-grained causal tracking used internally by observed-remove types (`or_set`, `or_map`).
+
+  All types include JSON serialization via `to_json`/`from_json`. See the [version vectors guide](https://lattice.tylerbutler.com/advanced/version-vectors/) for details.
+time: 2026-04-11T18:00:00.000000000Z

--- a/.changes/unreleased/lattice_core-Breaking-20260407-193633.yaml
+++ b/.changes/unreleased/lattice_core-Breaking-20260407-193633.yaml
@@ -3,5 +3,5 @@ kind: Breaking
 body: |-
   Extracted from monolithic `lattice` package into standalone `lattice_core` package
 
-  Imports change from `import lattice/version_vector` and `import lattice/dot_context` to `import lattice_core/version_vector` and `import lattice_core/dot_context`. Update all import paths accordingly.
+  Imports change from `import lattice/version_vector` and `import lattice/dot_context` to `import lattice_core/version_vector` and `import lattice_core/dot_context`. Update all import paths accordingly. See the [packages overview](https://lattice.tylerbutler.com/packages/) for the full package structure.
 time: 2026-04-07T19:36:33.000000000Z

--- a/.changes/unreleased/lattice_counters-Added-initial-api.yaml
+++ b/.changes/unreleased/lattice_counters-Added-initial-api.yaml
@@ -1,0 +1,15 @@
+project: lattice_counters
+kind: Added
+body: |-
+  Conflict-free replicated counter types
+
+  - **`g_counter`** — Grow-only counter for monotonically increasing values (e.g. event counts, page views). Supports `increment`, `value`, and `merge`. Use `try_increment` for explicit error handling on negative deltas.
+  - **`pn_counter`** — Positive-negative counter that supports both `increment` and `decrement` (e.g. inventory levels, user counts). Built on a pair of grow-only counters internally.
+
+  ```gleam
+  let counter = g_counter.new(replica_id.new("node-a")) |> g_counter.increment(5)
+  g_counter.value(counter)  // -> 5
+  ```
+
+  All types include JSON serialization via `to_json`/`from_json`. See the [counters guide](https://lattice.tylerbutler.com/guides/counters/) for details.
+time: 2026-04-11T18:00:01.000000000Z

--- a/.changes/unreleased/lattice_counters-Breaking-20260407-193633.yaml
+++ b/.changes/unreleased/lattice_counters-Breaking-20260407-193633.yaml
@@ -3,5 +3,5 @@ kind: Breaking
 body: |-
   Extracted from monolithic `lattice` package into standalone `lattice_counters` package
 
-  Imports change from `import lattice/g_counter` and `import lattice/pn_counter` to `import lattice_counters/g_counter` and `import lattice_counters/pn_counter`. Update all import paths accordingly.
+  Imports change from `import lattice/g_counter` and `import lattice/pn_counter` to `import lattice_counters/g_counter` and `import lattice_counters/pn_counter`. Update all import paths accordingly. See the [packages overview](https://lattice.tylerbutler.com/packages/) for the full package structure.
 time: 2026-04-07T19:36:33.000000000Z

--- a/.changes/unreleased/lattice_crdt-Breaking-20260407-193633.yaml
+++ b/.changes/unreleased/lattice_crdt-Breaking-20260407-193633.yaml
@@ -1,7 +1,18 @@
 project: lattice_crdt
 kind: Breaking
 body: |-
-  Split monolithic `lattice` package into multi-package monorepo
+  Split into multi-package monorepo
 
-  The single `lattice` package has been reorganized into 6 independently-versioned packages: `lattice_core`, `lattice_counters`, `lattice_sets`, `lattice_registers`, `lattice_maps`, and `lattice_crdt` (umbrella). All import paths change from `import lattice/<module>` to the appropriate sub-package (e.g. `import lattice/g_counter` becomes `import lattice_counters/g_counter`). Depend on `lattice_crdt` to get all sub-packages, or depend on individual packages for minimal dependencies. See each sub-package's changelog for complete import path mappings.
+  The single `lattice` package has been reorganized into 6 independently-versioned packages. You can depend on `lattice_crdt` to get everything, or depend on individual packages for smaller dependency footprints:
+
+  | Package | Contents |
+  |---------|----------|
+  | `lattice_core` | `version_vector`, `dot_context`, `replica_id` |
+  | `lattice_counters` | `g_counter`, `pn_counter` |
+  | `lattice_sets` | `g_set`, `two_p_set`, `or_set` |
+  | `lattice_registers` | `lww_register`, `mv_register` |
+  | `lattice_maps` | `lww_map`, `or_map`, `crdt` |
+  | `lattice_crdt` | Umbrella — depends on all above |
+
+  All import paths change from `import lattice/<module>` to the appropriate sub-package (e.g. `import lattice/g_counter` becomes `import lattice_counters/g_counter`). See the [packages overview](https://lattice.tylerbutler.com/packages/) for the full dependency graph.
 time: 2026-04-07T19:36:33.000000000Z

--- a/.changes/unreleased/lattice_crdt-Breaking-opaque-replica-id.yaml
+++ b/.changes/unreleased/lattice_crdt-Breaking-opaque-replica-id.yaml
@@ -1,6 +1,7 @@
 project: lattice_crdt
 kind: Breaking
 body: |-
-  Add opaque ReplicaId type for type-safe replica identification
-  Functions that previously accepted raw `String` replica identifiers now require a `ReplicaId` value. Create one with `replica_id.from_string("node-a")`. This affects `g_counter.new`, `pn_counter.new`, `lww_register.new`, `or_set.add`, `or_set.remove`, `lww_map.set`, `lww_map.remove`, `or_map.set`, and `or_map.remove`.
+  Add opaque `ReplicaId` type for type-safe replica identification
+
+  Functions that previously accepted raw `String` replica identifiers now require a `ReplicaId` value. Create one with `replica_id.new("node-a")`. This affects `g_counter.new`, `pn_counter.new`, `lww_register.new`, `or_set.new`, `mv_register.new`, and `or_map.new`. See the [replica IDs guide](https://lattice.tylerbutler.com/guides/replica-ids/) for details.
 time: 2026-04-07T21:59:20.405500000+00:00

--- a/.changes/unreleased/lattice_maps-Added-initial-api.yaml
+++ b/.changes/unreleased/lattice_maps-Added-initial-api.yaml
@@ -1,0 +1,16 @@
+project: lattice_maps
+kind: Added
+body: |-
+  Conflict-free replicated map types
+
+  - **`lww_map`** — Last-writer-wins map with timestamp-based conflict resolution per key. Supports `set`, `get`, `remove`, and `keys`. Removed keys leave tombstones; use `prune` to reclaim space.
+  - **`or_map`** — Observed-remove map where each key holds a nested CRDT value (counter, register, set, etc.). Use `update` with a callback to modify values, and `remove` to delete keys with add-wins semantics.
+  - **`crdt`** — Tagged union wrapper (`Crdt`) and spec type (`CrdtSpec`) for ORMap values. Supports all lattice CRDT types as nested values.
+
+  ```gleam
+  let map = lww_map.new() |> lww_map.set("name", "Alice", 1)
+  lww_map.get(map, "name")  // -> Ok("Alice")
+  ```
+
+  All types include JSON serialization via `to_json`/`from_json`. See the [maps guide](https://lattice.tylerbutler.com/guides/maps/) for details.
+time: 2026-04-11T18:00:04.000000000Z

--- a/.changes/unreleased/lattice_maps-Added-ormap-prune.yaml
+++ b/.changes/unreleased/lattice_maps-Added-ormap-prune.yaml
@@ -1,7 +1,7 @@
 project: lattice_maps
 kind: Added
 body: |-
-  Add `or_map.prune(stable_vv)` for tombstone and value compaction
+  Add `or_map.prune(stable_vv)` for garbage collection
 
-  Delegates to `or_set.prune` on the internal key tracker and compacts CRDT values for removed keys whose removal is causally stable (the pruned version vector dominates the remove bound). Values for removed keys with unstable removals are retained for concurrent merge correctness. The JSON serialization format is bumped to v2 to persist remove bounds; v1 payloads are still accepted on read with empty bounds.
+  Call `or_map.prune(map, stable_vv)` with a version vector that all replicas have acknowledged to reclaim memory from removed keys and their associated CRDT values. Removals that are not yet causally stable are preserved to maintain merge correctness across replicas. The JSON format is bumped to v2 to persist removal metadata; v1 payloads are still accepted on read.
 time: 2026-04-07T20:00:02.000000000Z

--- a/.changes/unreleased/lattice_maps-Breaking-20260407-193633.yaml
+++ b/.changes/unreleased/lattice_maps-Breaking-20260407-193633.yaml
@@ -3,5 +3,5 @@ kind: Breaking
 body: |-
   Extracted from monolithic `lattice` package into standalone `lattice_maps` package
 
-  Imports change from `import lattice/lww_map`, `import lattice/or_map`, and `import lattice/crdt` to `import lattice_maps/lww_map`, `import lattice_maps/or_map`, and `import lattice_maps/crdt`. Update all import paths accordingly.
+  Imports change from `import lattice/lww_map`, `import lattice/or_map`, and `import lattice/crdt` to `import lattice_maps/lww_map`, `import lattice_maps/or_map`, and `import lattice_maps/crdt`. Update all import paths accordingly. See the [packages overview](https://lattice.tylerbutler.com/packages/) for the full package structure.
 time: 2026-04-07T19:36:33.000000000Z

--- a/.changes/unreleased/lattice_maps-Breaking-merge-result-type.yaml
+++ b/.changes/unreleased/lattice_maps-Breaking-merge-result-type.yaml
@@ -7,5 +7,5 @@ body: |-
   `Error(TypeMismatch(expected: ..., found: ...))` instead of silently returning
   the first argument. `or_map.merge(a, b)` returns `Result(ORMap, MergeError)` —
   spec mismatches produce the same error. Callers must handle the `Result`;
-  for same-type merges, `let assert Ok(merged) = crdt.merge(a, b)` is idiomatic.
+  for same-type merges, `let assert Ok(merged) = crdt.merge(a, b)` is idiomatic. See the [maps guide](https://lattice.tylerbutler.com/guides/maps/) for usage examples.
 time: 2026-04-08T22:39:57.000000000+00:00

--- a/.changes/unreleased/lattice_maps-Fixed-lww-map-zombie-pruning.yaml
+++ b/.changes/unreleased/lattice_maps-Fixed-lww-map-zombie-pruning.yaml
@@ -1,11 +1,7 @@
 project: lattice_maps
 kind: Fixed
 body: |-
-  LWWMap `prune` now prevents zombie resurrections on merge
+  LWWMap `prune` now prevents deleted keys from reappearing after merge
 
-  `prune` records a `pruned_timestamp` in the LWWMap. During `merge`, entries from
-  remote replicas with timestamps at or below the other side's pruned threshold are
-  automatically discarded, preventing deleted keys from reappearing. JSON
-  serialization is bumped to v2 to persist the pruned timestamp; `from_json` still
-  accepts v1 (with pruned timestamp defaulting to 0).
+  Previously, pruning tombstones from one replica could cause deleted keys to reappear when merging with a stale replica that still had the old entry. `prune` now records a `pruned_timestamp` so that `merge` automatically discards entries at or below the pruned threshold. JSON serialization is bumped to v2 to persist the pruned timestamp; `from_json` still accepts v1.
 time: 2026-04-08T21:53:33.000000000+00:00

--- a/.changes/unreleased/lattice_registers-Added-initial-api.yaml
+++ b/.changes/unreleased/lattice_registers-Added-initial-api.yaml
@@ -1,0 +1,17 @@
+project: lattice_registers
+kind: Added
+body: |-
+  Conflict-free replicated register types
+
+  - **`lww_register`** — Last-writer-wins register. Resolves conflicts by timestamp; the most recent write wins. Use for values where "latest update wins" is acceptable (e.g. user profile fields).
+  - **`mv_register`** — Multi-value register. Preserves all concurrent writes, returning them as a list via `value`. Use when your application needs to present or resolve conflicts explicitly.
+
+  ```gleam
+  // Concurrent writes to an MV register are all preserved
+  let a = mv_register.new(replica_id.new("node-a")) |> mv_register.set("hello")
+  let b = mv_register.new(replica_id.new("node-b")) |> mv_register.set("world")
+  mv_register.value(mv_register.merge(a, b))  // -> ["hello", "world"]
+  ```
+
+  All types include JSON serialization via `to_json`/`from_json`. See the [registers guide](https://lattice.tylerbutler.com/guides/registers/) for details.
+time: 2026-04-11T18:00:03.000000000Z

--- a/.changes/unreleased/lattice_registers-Breaking-20260407-193633.yaml
+++ b/.changes/unreleased/lattice_registers-Breaking-20260407-193633.yaml
@@ -3,5 +3,5 @@ kind: Breaking
 body: |-
   Extracted from monolithic `lattice` package into standalone `lattice_registers` package
 
-  Imports change from `import lattice/lww_register` and `import lattice/mv_register` to `import lattice_registers/lww_register` and `import lattice_registers/mv_register`. Update all import paths accordingly.
+  Imports change from `import lattice/lww_register` and `import lattice/mv_register` to `import lattice_registers/lww_register` and `import lattice_registers/mv_register`. Update all import paths accordingly. See the [packages overview](https://lattice.tylerbutler.com/packages/) for the full package structure.
 time: 2026-04-07T19:36:33.000000000Z

--- a/.changes/unreleased/lattice_registers-Fixed-mv-register-causality.yaml
+++ b/.changes/unreleased/lattice_registers-Fixed-mv-register-causality.yaml
@@ -1,7 +1,7 @@
 project: lattice_registers
 kind: Fixed
 body: |-
-  Enforce causality invariants during MVRegister JSON deserialization
+  Validate MVRegister state during JSON deserialization
 
-  Entry tags are now validated to have positive counters and must not exceed the attached version vector, preventing causally inconsistent state from being decoded.
+  `mv_register.from_json` now rejects payloads with invalid causal metadata (e.g. negative counters or tags that exceed the version vector). Previously, malformed JSON could produce a register in an inconsistent state that would behave incorrectly on merge.
 time: 2026-04-07T22:32:00.000000000Z

--- a/.changes/unreleased/lattice_sets-Added-20260411-163301.yaml
+++ b/.changes/unreleased/lattice_sets-Added-20260411-163301.yaml
@@ -3,5 +3,5 @@ kind: Added
 body: |-
   Add `or_set.remove_with_bound` and `or_set.pruned_vv`
 
-  `remove_with_bound` behaves like `remove` but also returns a `VersionVector` representing the causal bound of the removed tags. `pruned_vv` exposes the causal horizon below which tombstones have been garbage collected. Together these enable downstream data structures (e.g. ORMap) to determine when a removal is causally stable and safely discard associated values.
+  `remove_with_bound(set, element)` works like `remove` but also returns a `VersionVector` representing the causal context of the removal. `pruned_vv(set)` returns the version vector below which tombstones have been garbage-collected. These are primarily useful for building higher-level data structures like `or_map` that need to track when a removal is safe to finalize.
 time: 2026-04-11T16:33:01.000000000Z

--- a/.changes/unreleased/lattice_sets-Added-initial-api.yaml
+++ b/.changes/unreleased/lattice_sets-Added-initial-api.yaml
@@ -1,0 +1,19 @@
+project: lattice_sets
+kind: Added
+body: |-
+  Conflict-free replicated set types
+
+  Three set types with different trade-offs:
+
+  - **`g_set`** — Grow-only. Elements can be added but never removed. Simplest and most efficient.
+  - **`two_p_set`** — Two-phase. Elements can be removed once, but a removed element can never be re-added.
+  - **`or_set`** — Observed-remove. Elements can be freely added and removed with add-wins semantics: if one replica adds an element while another concurrently removes it, the add wins.
+
+  ```gleam
+  let a = or_set.new(replica_id.new("node-a")) |> or_set.add("item")
+  let b = or_set.new(replica_id.new("node-b")) |> or_set.add("item") |> or_set.remove("item")
+  or_set.contains(or_set.merge(a, b), "item")  // -> True (add wins)
+  ```
+
+  All types include JSON serialization via `to_json`/`from_json`. See the [sets guide](https://lattice.tylerbutler.com/guides/sets/) for details.
+time: 2026-04-11T18:00:02.000000000Z

--- a/.changes/unreleased/lattice_sets-Added-orset-prune.yaml
+++ b/.changes/unreleased/lattice_sets-Added-orset-prune.yaml
@@ -3,5 +3,5 @@ kind: Added
 body: |-
   Add `or_set.prune(stable_vv)` for tombstone compaction
 
-  Accepts a causally stable version vector and removes tombstones dominated by it. The merge algorithm now detects "zombie" tags from stale replicas, preventing resurrection of removed elements after pruning. This resolves the known resurrection bug (#27).
+  Call `or_set.prune(set, stable_vv)` with a version vector that all replicas have acknowledged to reclaim memory from removed elements. The merge algorithm detects stale tags from replicas that haven't caught up, preventing removed elements from reappearing after pruning.
 time: 2026-04-07T20:00:00.000000000Z

--- a/.changes/unreleased/lattice_sets-Breaking-20260407-193633.yaml
+++ b/.changes/unreleased/lattice_sets-Breaking-20260407-193633.yaml
@@ -3,5 +3,5 @@ kind: Breaking
 body: |-
   Extracted from monolithic `lattice` package into standalone `lattice_sets` package
 
-  Imports change from `import lattice/g_set`, `import lattice/two_p_set`, and `import lattice/or_set` to `import lattice_sets/g_set`, `import lattice_sets/two_p_set`, and `import lattice_sets/or_set`. Update all import paths accordingly.
+  Imports change from `import lattice/g_set`, `import lattice/two_p_set`, and `import lattice/or_set` to `import lattice_sets/g_set`, `import lattice_sets/two_p_set`, and `import lattice_sets/or_set`. Update all import paths accordingly. See the [packages overview](https://lattice.tylerbutler.com/packages/) for the full package structure.
 time: 2026-04-07T19:36:33.000000000Z

--- a/.changes/v1.0.0.md
+++ b/.changes/v1.0.0.md
@@ -1,29 +1,72 @@
 ## v1.0.0 - 2026-03-06
 
+Initial release of lattice — a [CRDT](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type) library for Gleam targeting both Erlang and JavaScript runtimes. Every type converges automatically when replicas merge, with no coordination required. See the [documentation](https://lattice.tylerbutler.com) for guides and API reference.
 
 #### Added
 
 ##### Counter types
 
-Grow-only counters (`g_counter`) and positive-negative counters (`pn_counter`) that automatically converge across replicas.
+Grow-only counters (`g_counter`) for monotonically increasing values, and positive-negative counters (`pn_counter`) that support both increment and decrement. Use `g_counter` when values only go up (e.g. event counts); use `pn_counter` when you need subtraction (e.g. inventory levels).
+
+```gleam
+let counter = g_counter.new("node-a") |> g_counter.increment(5)
+g_counter.value(counter)  // -> 5
+
+// Merge two replicas — values combine automatically
+let merged = g_counter.merge(counter_a, counter_b)
+```
 
 ##### Register types
 
-Last-writer-wins registers (`lww_register`) and multi-value registers (`mv_register`) for storing single values with conflict resolution.
+Last-writer-wins registers (`lww_register`) resolve conflicts by timestamp — the most recent write wins. Multi-value registers (`mv_register`) preserve all concurrent writes, letting your application decide how to resolve them.
+
+```gleam
+// LWW: latest timestamp wins
+let reg = lww_register.new("initial", 1, "node-a")
+let reg = lww_register.set(reg, "updated", 2)
+
+// MV: concurrent writes are all preserved
+let merged = mv_register.merge(reg_a, reg_b)
+mv_register.value(merged)  // -> ["value-a", "value-b"]
+```
 
 ##### Set types
 
-Grow-only sets (`g_set`), two-phase sets with remove-once semantics (`two_p_set`), and observed-remove sets (`or_set`) for managing collections across replicas.
+Three set types with different trade-offs:
+
+- **`g_set`** — Grow-only. Elements can be added but never removed. Simplest and most efficient.
+- **`two_p_set`** — Two-phase. Elements can be removed once, but a removed element can never be re-added.
+- **`or_set`** — Observed-remove. Elements can be freely added and removed. Concurrent add and remove of the same element resolves in favor of the add (add-wins semantics).
+
+```gleam
+let a = or_set.new("node-a") |> or_set.add("item")
+let b = or_set.new("node-b") |> or_set.add("item") |> or_set.remove("item")
+let merged = or_set.merge(a, b)
+or_set.contains(merged, "item")  // -> True (add wins)
+```
 
 ##### Map types
 
-Last-writer-wins maps (`lww_map`) and observed-remove maps (`or_map`) for key-value storage with automatic conflict resolution.
+Key-value maps with automatic conflict resolution:
+
+- **`lww_map`** — Last-writer-wins semantics per key, with timestamp-based conflict resolution. Supports `remove` with tombstones.
+- **`or_map`** — Observed-remove semantics with nested CRDT values. Each key holds a full CRDT (counter, register, set, etc.) that merges independently.
+
+```gleam
+let map = lww_map.new() |> lww_map.set("name", "Alice", 1)
+lww_map.get(map, "name")  // -> Ok("Alice")
+```
 
 ##### Causal context primitives
 
-Version vectors (`version_vector`) and dot contexts (`dot_context`) for tracking causality between replicas.
+Version vectors (`version_vector`) for tracking happened-before relationships between replicas, and dot contexts (`dot_context`) for fine-grained causal tracking used internally by `or_set` and `or_map`. You typically interact with version vectors directly when configuring advanced merge or pruning behavior.
 
 ##### JSON serialization
 
-All CRDT types include `to_json` and `from_json` functions for persisting and transmitting state between nodes.
+All types include `to_json` and `from_json` functions for persisting state and transmitting it between nodes.
+
+```gleam
+let json_str = g_counter.to_json(counter) |> json.to_string
+let assert Ok(restored) = g_counter.from_json(json_str)
+```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,31 +7,74 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v1.0.0 - 2026-03-06
 
+Initial release of lattice — a [CRDT](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type) library for Gleam targeting both Erlang and JavaScript runtimes. Every type converges automatically when replicas merge, with no coordination required. See the [documentation](https://lattice.tylerbutler.com) for guides and API reference.
 
 #### Added
 
 ##### Counter types
 
-Grow-only counters (`g_counter`) and positive-negative counters (`pn_counter`) that automatically converge across replicas.
+Grow-only counters (`g_counter`) for monotonically increasing values, and positive-negative counters (`pn_counter`) that support both increment and decrement. Use `g_counter` when values only go up (e.g. event counts); use `pn_counter` when you need subtraction (e.g. inventory levels).
+
+```gleam
+let counter = g_counter.new("node-a") |> g_counter.increment(5)
+g_counter.value(counter)  // -> 5
+
+// Merge two replicas — values combine automatically
+let merged = g_counter.merge(counter_a, counter_b)
+```
 
 ##### Register types
 
-Last-writer-wins registers (`lww_register`) and multi-value registers (`mv_register`) for storing single values with conflict resolution.
+Last-writer-wins registers (`lww_register`) resolve conflicts by timestamp — the most recent write wins. Multi-value registers (`mv_register`) preserve all concurrent writes, letting your application decide how to resolve them.
+
+```gleam
+// LWW: latest timestamp wins
+let reg = lww_register.new("initial", 1, "node-a")
+let reg = lww_register.set(reg, "updated", 2)
+
+// MV: concurrent writes are all preserved
+let merged = mv_register.merge(reg_a, reg_b)
+mv_register.value(merged)  // -> ["value-a", "value-b"]
+```
 
 ##### Set types
 
-Grow-only sets (`g_set`), two-phase sets with remove-once semantics (`two_p_set`), and observed-remove sets (`or_set`) for managing collections across replicas.
+Three set types with different trade-offs:
+
+- **`g_set`** — Grow-only. Elements can be added but never removed. Simplest and most efficient.
+- **`two_p_set`** — Two-phase. Elements can be removed once, but a removed element can never be re-added.
+- **`or_set`** — Observed-remove. Elements can be freely added and removed. Concurrent add and remove of the same element resolves in favor of the add (add-wins semantics).
+
+```gleam
+let a = or_set.new("node-a") |> or_set.add("item")
+let b = or_set.new("node-b") |> or_set.add("item") |> or_set.remove("item")
+let merged = or_set.merge(a, b)
+or_set.contains(merged, "item")  // -> True (add wins)
+```
 
 ##### Map types
 
-Last-writer-wins maps (`lww_map`) and observed-remove maps (`or_map`) for key-value storage with automatic conflict resolution.
+Key-value maps with automatic conflict resolution:
+
+- **`lww_map`** — Last-writer-wins semantics per key, with timestamp-based conflict resolution. Supports `remove` with tombstones.
+- **`or_map`** — Observed-remove semantics with nested CRDT values. Each key holds a full CRDT (counter, register, set, etc.) that merges independently.
+
+```gleam
+let map = lww_map.new() |> lww_map.set("name", "Alice", 1)
+lww_map.get(map, "name")  // -> Ok("Alice")
+```
 
 ##### Causal context primitives
 
-Version vectors (`version_vector`) and dot contexts (`dot_context`) for tracking causality between replicas.
+Version vectors (`version_vector`) for tracking happened-before relationships between replicas, and dot contexts (`dot_context`) for fine-grained causal tracking used internally by `or_set` and `or_map`. You typically interact with version vectors directly when configuring advanced merge or pruning behavior.
 
 ##### JSON serialization
 
-All CRDT types include `to_json` and `from_json` functions for persisting and transmitting state between nodes.
+All types include `to_json` and `from_json` functions for persisting state and transmitting it between nodes.
+
+```gleam
+let json_str = g_counter.to_json(counter) |> json.to_string
+let assert Ok(restored) = g_counter.from_json(json_str)
+```
 
 

--- a/packages/lattice_crdt/CHANGELOG.md
+++ b/packages/lattice_crdt/CHANGELOG.md
@@ -7,29 +7,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v1.0.0 - 2026-03-06
 
+Initial release of lattice — a [CRDT](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type) library for Gleam targeting both Erlang and JavaScript runtimes. Every type converges automatically when replicas merge, with no coordination required. See the [documentation](https://lattice.tylerbutler.com) for guides and API reference.
 
 #### Added
 
 ##### Counter types
 
-Grow-only counters (`g_counter`) and positive-negative counters (`pn_counter`) that automatically converge across replicas.
+Grow-only counters (`g_counter`) for monotonically increasing values, and positive-negative counters (`pn_counter`) that support both increment and decrement. Use `g_counter` when values only go up (e.g. event counts); use `pn_counter` when you need subtraction (e.g. inventory levels).
+
+```gleam
+let counter = g_counter.new("node-a") |> g_counter.increment(5)
+g_counter.value(counter)  // -> 5
+
+// Merge two replicas — values combine automatically
+let merged = g_counter.merge(counter_a, counter_b)
+```
 
 ##### Register types
 
-Last-writer-wins registers (`lww_register`) and multi-value registers (`mv_register`) for storing single values with conflict resolution.
+Last-writer-wins registers (`lww_register`) resolve conflicts by timestamp — the most recent write wins. Multi-value registers (`mv_register`) preserve all concurrent writes, letting your application decide how to resolve them.
+
+```gleam
+// LWW: latest timestamp wins
+let reg = lww_register.new("initial", 1, "node-a")
+let reg = lww_register.set(reg, "updated", 2)
+
+// MV: concurrent writes are all preserved
+let merged = mv_register.merge(reg_a, reg_b)
+mv_register.value(merged)  // -> ["value-a", "value-b"]
+```
 
 ##### Set types
 
-Grow-only sets (`g_set`), two-phase sets with remove-once semantics (`two_p_set`), and observed-remove sets (`or_set`) for managing collections across replicas.
+Three set types with different trade-offs:
+
+- **`g_set`** — Grow-only. Elements can be added but never removed. Simplest and most efficient.
+- **`two_p_set`** — Two-phase. Elements can be removed once, but a removed element can never be re-added.
+- **`or_set`** — Observed-remove. Elements can be freely added and removed. Concurrent add and remove of the same element resolves in favor of the add (add-wins semantics).
+
+```gleam
+let a = or_set.new("node-a") |> or_set.add("item")
+let b = or_set.new("node-b") |> or_set.add("item") |> or_set.remove("item")
+let merged = or_set.merge(a, b)
+or_set.contains(merged, "item")  // -> True (add wins)
+```
 
 ##### Map types
 
-Last-writer-wins maps (`lww_map`) and observed-remove maps (`or_map`) for key-value storage with automatic conflict resolution.
+Key-value maps with automatic conflict resolution:
+
+- **`lww_map`** — Last-writer-wins semantics per key, with timestamp-based conflict resolution. Supports `remove` with tombstones.
+- **`or_map`** — Observed-remove semantics with nested CRDT values. Each key holds a full CRDT (counter, register, set, etc.) that merges independently.
+
+```gleam
+let map = lww_map.new() |> lww_map.set("name", "Alice", 1)
+lww_map.get(map, "name")  // -> Ok("Alice")
+```
 
 ##### Causal context primitives
 
-Version vectors (`version_vector`) and dot contexts (`dot_context`) for tracking causality between replicas.
+Version vectors (`version_vector`) for tracking happened-before relationships between replicas, and dot contexts (`dot_context`) for fine-grained causal tracking used internally by `or_set` and `or_map`. You typically interact with version vectors directly when configuring advanced merge or pruning behavior.
 
 ##### JSON serialization
 
-All CRDT types include `to_json` and `from_json` functions for persisting and transmitting state between nodes.
+All types include `to_json` and `from_json` functions for persisting state and transmitting it between nodes.
+
+```gleam
+let json_str = g_counter.to_json(counter) |> json.to_string
+let assert Ok(restored) = g_counter.from_json(json_str)
+```


### PR DESCRIPTION
## Summary

- **Rewrite v1.0.0 entries** with intro paragraph, code examples, when-to-use guidance, and links to [lattice.tylerbutler.com](https://lattice.tylerbutler.com)
- **Add initial "Added" entries** for each sub-package (`lattice_core`, `lattice_counters`, `lattice_sets`, `lattice_registers`, `lattice_maps`) so their first release changelog describes what the package provides — not just that it was extracted from the monolith
- **Fix and improve existing unreleased entries**: correct `replica_id.from_string` → `replica_id.new`, simplify implementation jargon for user-facing readability, and add documentation links throughout

## Test plan

- [x] `changie batch auto --dry-run --project <pkg>` validates all entries parse correctly for every package
- [ ] Review rendered markdown in PR diff for formatting issues
- [ ] Verify documentation links resolve to correct pages on lattice.tylerbutler.com