### PR TITLE
ci: update auto-tag workflow to fixed upstream SHA

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   auto-tag:
-    uses: tylerbutler/actions/.github/workflows/auto-tag.yml@4d7b8407d2c23fd22c750af2504940b13bdc3ee5 # ratchet:tylerbutler/actions/.github/workflows/auto-tag.yml@main
+    uses: tylerbutler/actions/.github/workflows/auto-tag.yml@a9225b67462603a5aebff2450a7ef02b820b6eb7 # ratchet:tylerbutler/actions/.github/workflows/auto-tag.yml@main
     with:
       workspace-file: workspace.toml
       create-release: true


### PR DESCRIPTION
## Summary

- Update pinned SHA for `tylerbutler/actions/.github/workflows/auto-tag.yml` to `a9225b6` which includes the fix from tylerbutler/actions#30
- Fixes the `Unrecognized named-value: 'secrets'` parse error that has caused every auto-tag workflow run to fail since March 7

## Test plan

- [ ] Verify the auto-tag workflow no longer fails with "workflow file issue" when this PR is closed/merged