### PR TITLE
feat(sets): add ORSet ergonomic helpers

### DIFF
--- a/.changes/unreleased/lattice_sets-Added-orset-ergonomics.yaml
+++ b/.changes/unreleased/lattice_sets-Added-orset-ergonomics.yaml
@@ -1,0 +1,7 @@
+project: lattice_sets
+kind: Added
+body: |-
+  Add ORSet ergonomic helpers for adapter code
+
+  Adds `or_set.Diff`, `or_set.diff`, `or_set.merge_with_diff`, `or_set.remove_all`, and `or_set.remove_where` for consumers that need observable value changes or bulk removals without inspecting internal tags.
+time: 2026-05-16T15:18:06.000000000Z

--- a/packages/lattice_sets/src/lattice_sets/or_set.gleam
+++ b/packages/lattice_sets/src/lattice_sets/or_set.gleam
@@ -59,6 +59,15 @@ pub opaque type ORSet(a) {
   )
 }
 
+/// Observable value changes between two OR-Sets.
+///
+/// Diff values are based on `value`, not internal tags. Re-adding an element
+/// that was already observable does not appear in `added`; removing one tag
+/// while another live tag remains does not appear in `removed`.
+pub type Diff(a) {
+  Diff(added: set.Set(a), removed: set.Set(a))
+}
+
 /// Create a new empty OR-Set for the given replica.
 ///
 /// Each replica should have a unique `replica_id` to ensure that tags
@@ -108,6 +117,26 @@ pub fn remove(orset: ORSet(a), element: a) -> ORSet(a) {
   )
 }
 
+/// Remove each element in `elements` using observed-remove semantics.
+///
+/// Missing elements are ignored, matching `remove`.
+pub fn remove_all(orset: ORSet(a), elements: List(a)) -> ORSet(a) {
+  list.fold(elements, orset, fn(acc, element) { remove(acc, element) })
+}
+
+/// Remove every currently observable element matching `predicate`.
+///
+/// The predicate is evaluated against `value(orset)`, then each matching value
+/// is removed with normal observed-remove semantics.
+pub fn remove_where(orset: ORSet(a), predicate: fn(a) -> Bool) -> ORSet(a) {
+  let elements =
+    value(orset)
+    |> set.to_list
+    |> list.filter(predicate)
+
+  remove_all(orset, elements)
+}
+
 /// Check if the set contains the given element.
 ///
 /// Returns `True` if the element has at least one live tag (i.e., it has
@@ -128,6 +157,20 @@ pub fn value(orset: ORSet(a)) -> set.Set(a) {
   // (via merge/remove logic).
   dict.keys(orset.entries)
   |> set.from_list
+}
+
+/// Compare the observable values of two OR-Sets.
+///
+/// `added` contains values present in `after` but not `before`.
+/// `removed` contains values present in `before` but not `after`.
+pub fn diff(before: ORSet(a), after: ORSet(a)) -> Diff(a) {
+  let before_values = value(before)
+  let after_values = value(after)
+
+  Diff(
+    added: set.difference(after_values, before_values),
+    removed: set.difference(before_values, after_values),
+  )
 }
 
 /// Merge two OR-Sets.
@@ -177,6 +220,19 @@ pub fn merge(a: ORSet(el), b: ORSet(el)) -> ORSet(el) {
     tombstones: merged_tombstones,
     pruned: merged_pruned,
   )
+}
+
+/// Merge two OR-Sets and report observable value changes from `local`.
+///
+/// The returned OR-Set is exactly the same as `merge(local, remote)`. The
+/// diff compares `value(local)` with `value(merged)`, so it reports only
+/// externally visible additions and removals.
+pub fn merge_with_diff(
+  local: ORSet(a),
+  remote: ORSet(a),
+) -> #(ORSet(a), Diff(a)) {
+  let merged = merge(local, remote)
+  #(merged, diff(local, merged))
 }
 
 fn not_dominated(tag: Tag, pruned: VersionVector) -> Bool {

--- a/packages/lattice_sets/test/set/or_set_test.gleam
+++ b/packages/lattice_sets/test/set/or_set_test.gleam
@@ -1,4 +1,5 @@
 import gleam/set
+import gleam/string
 import lattice_core/replica_id
 import lattice_core/version_vector
 import lattice_sets/or_set
@@ -35,6 +36,33 @@ pub fn add_then_value_contains_element_test() {
   |> expect.to_equal(set.from_list(["hello"]))
 }
 
+pub fn diff_reports_added_and_removed_values_test() {
+  let before =
+    or_set.new(rid("A"))
+    |> or_set.add("stays")
+    |> or_set.add("removed")
+
+  let after =
+    before
+    |> or_set.remove("removed")
+    |> or_set.add("added")
+
+  let or_set.Diff(added, removed) = or_set.diff(before, after)
+
+  added |> expect.to_equal(set.from_list(["added"]))
+  removed |> expect.to_equal(set.from_list(["removed"]))
+}
+
+pub fn diff_empty_when_observable_values_unchanged_test() {
+  let before = or_set.new(rid("A")) |> or_set.add("same")
+  let after = before |> or_set.add("same")
+
+  let or_set.Diff(added, removed) = or_set.diff(before, after)
+
+  added |> expect.to_equal(set.new())
+  removed |> expect.to_equal(set.new())
+}
+
 pub fn add_then_remove_then_contains_false_test() {
   or_set.new(rid("A"))
   |> or_set.add("x")
@@ -52,6 +80,45 @@ pub fn re_add_after_remove_contains_true_test() {
   |> or_set.add("x")
   |> or_set.contains("x")
   |> expect.to_be_true
+}
+
+pub fn remove_all_removes_each_observed_element_test() {
+  let orset =
+    or_set.new(rid("A"))
+    |> or_set.add("a")
+    |> or_set.add("b")
+    |> or_set.add("c")
+
+  orset
+  |> or_set.remove_all(["a", "c", "missing"])
+  |> or_set.value
+  |> expect.to_equal(set.from_list(["b"]))
+}
+
+pub fn remove_where_removes_matching_observed_values_test() {
+  let orset =
+    or_set.new(rid("A"))
+    |> or_set.add("keep")
+    |> or_set.add("remove-1")
+    |> or_set.add("remove-2")
+
+  orset
+  |> or_set.remove_where(fn(value) { string.starts_with(value, "remove") })
+  |> or_set.value
+  |> expect.to_equal(set.from_list(["keep"]))
+}
+
+pub fn remove_where_preserves_add_wins_semantics_test() {
+  let replica_a = or_set.new(rid("A")) |> or_set.add("x")
+  let replica_b =
+    or_set.new(rid("B"))
+    |> or_set.merge(replica_a)
+    |> or_set.remove_where(fn(value) { value == "x" })
+  let replica_a = replica_a |> or_set.add("x")
+
+  or_set.merge(replica_a, replica_b)
+  |> or_set.contains("x")
+  |> expect.to_be_true()
 }
 
 pub fn add_multiple_elements_test() {
@@ -135,6 +202,48 @@ pub fn merge_union_tags_test() {
   or_set.merge(set_a, set_b)
   |> or_set.value
   |> expect.to_equal(set.from_list(["a", "b", "c"]))
+}
+
+pub fn merge_with_diff_matches_merge_result_test() {
+  let local = or_set.new(rid("A")) |> or_set.add("local")
+  let remote = or_set.new(rid("B")) |> or_set.add("remote")
+
+  let #(merged, _) = or_set.merge_with_diff(local, remote)
+
+  or_set.value(merged)
+  |> expect.to_equal(or_set.value(or_set.merge(local, remote)))
+}
+
+pub fn merge_with_diff_reports_added_values_test() {
+  let local = or_set.new(rid("A")) |> or_set.add("local")
+  let remote = or_set.new(rid("B")) |> or_set.add("remote")
+
+  let #(_, or_set.Diff(added, removed)) = or_set.merge_with_diff(local, remote)
+
+  added |> expect.to_equal(set.from_list(["remote"]))
+  removed |> expect.to_equal(set.new())
+}
+
+pub fn merge_with_diff_reports_removed_values_test() {
+  let local = or_set.new(rid("A")) |> or_set.add("shared")
+  let remote = local |> or_set.remove("shared")
+
+  let #(_, or_set.Diff(added, removed)) = or_set.merge_with_diff(local, remote)
+
+  added |> expect.to_equal(set.new())
+  removed |> expect.to_equal(set.from_list(["shared"]))
+}
+
+pub fn repeated_merge_with_diff_returns_empty_diff_test() {
+  let local = or_set.new(rid("A")) |> or_set.add("local")
+  let remote = or_set.new(rid("B")) |> or_set.add("remote")
+  let #(merged_once, _) = or_set.merge_with_diff(local, remote)
+
+  let #(_, or_set.Diff(added, removed)) =
+    or_set.merge_with_diff(merged_once, remote)
+
+  added |> expect.to_equal(set.new())
+  removed |> expect.to_equal(set.new())
 }
 
 pub fn merge_propagates_counter_test() {


### PR DESCRIPTION
## Summary

- Add value-level ORSet diff helpers: `Diff`, `diff`, and `merge_with_diff`
- Add bulk removal helpers: `remove_all` and `remove_where`
- Add tests and a `lattice_sets` changelog fragment

## Notes

This implements the warranted subset of #63. Generic ORSet JSON and safe introspection remain deferred because `lattice_presence` now uses a domain-specific Phoenix-style causal CRDT and there is not yet an in-repo typed-ORSet consumer that proves those APIs.

Refs #63

## Testing

- `just format`
- `just test-pkg lattice_sets`
- `cd packages/lattice_sets && gleam test --target javascript`
- `changie batch auto --dry-run --project lattice_sets`
- `just check`
