### PR TITLE
ci: refresh local gleam locks during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,9 @@ jobs:
           post-batch-command: |
             echo "Refreshing lockfiles after version bumps..."
             for d in packages/lattice_*/; do
-              [ -f "$d/gleam.toml" ] && (cd "$d" && gleam deps download)
+              [ -f "$d/gleam.toml" ] || continue
+              deps=$(grep -E '^lattice_[a-z_]+ = \{ path =' "$d/gleam.toml" | cut -d= -f1 | xargs || true)
+              [ -n "$deps" ] && (cd "$d" && gleam update $deps)
             done
 
       - name: Summary


### PR DESCRIPTION
## Summary
- update the Changie release post-batch hook to refresh local lattice path dependencies with `gleam update`
- skip packages without local lattice path dependencies so the hook works under `-e -o pipefail`

## Validation
- reproduced the previous `gleam deps download` lockfile mismatch after simulated version bumps
- verified the new targeted command succeeds under `bash -e -o pipefail`