### PR TITLE
chore(presence): prepare 1.0 release

### DIFF
--- a/.changes/unreleased/lattice_presence-Breaking-initial-release.yaml
+++ b/.changes/unreleased/lattice_presence-Breaking-initial-release.yaml
@@ -1,7 +1,7 @@
 project: lattice_presence
-kind: Added
+kind: Breaking
 body: |-
-    Initial release: pure distributed presence CRDT.
+    Initial release: pure distributed presence CRDT
 
     Provides `lattice_presence/presence_state` with topic/key/pid/meta tracking,
     opaque CRDT state, add-wins observed-remove semantics, replica up/down

--- a/packages/lattice_presence/gleam.toml
+++ b/packages/lattice_presence/gleam.toml
@@ -1,5 +1,5 @@
 name = "lattice_presence"
-version = "1.0.0"
+version = "0.1.0"
 description = "Distributed presence CRDT with topic/key/pid/meta tracking, add-wins merge semantics, replica visibility, and Phoenix-style diff reporting"
 licences = ["MIT"]
 repository = { type = "github", user = "tylerbutler", repo = "lattice" }

--- a/packages/lattice_presence/gleam.toml
+++ b/packages/lattice_presence/gleam.toml
@@ -1,5 +1,5 @@
 name = "lattice_presence"
-version = "0.1.0"
+version = "1.0.0"
 description = "Distributed presence CRDT with topic/key/pid/meta tracking, add-wins merge semantics, replica visibility, and Phoenix-style diff reporting"
 licences = ["MIT"]
 repository = { type = "github", user = "tylerbutler", repo = "lattice" }


### PR DESCRIPTION
## Summary

- Convert the initial release changie fragment to `Breaking` so release automation batches Presence as `v1.0.0`

## Validation

- `just check`
- `changie batch auto --dry-run --project lattice_presence`
