### PR TITLE
ci: pin fixed auto-tag action

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   auto-tag:
-    uses: tylerbutler/actions/.github/workflows/auto-tag.yml@d67948fe17fa338034eb7cff2ef51779992438a3 # ratchet:tylerbutler/actions/.github/workflows/auto-tag.yml@main
+    uses: tylerbutler/actions/.github/workflows/auto-tag.yml@5b210da843bed1c39bc1208d4a66964b488e2b5b # ratchet:tylerbutler/actions/.github/workflows/auto-tag.yml@main
     with:
       workspace-file: workspace.toml
       create-release: true


### PR DESCRIPTION
## Summary
- update the auto-tag reusable workflow pin to the merged upstream fix
- prevents unchanged packages with existing remote tags from failing future release tagging

## Test
- git diff --check .github/workflows/auto-tag.yml