### PR TITLE
docs: add package READMEs

### DIFF
--- a/packages/lattice_core/README.md
+++ b/packages/lattice_core/README.md
@@ -1,0 +1,59 @@
+# lattice_core
+
+Core causal infrastructure for Lattice CRDT packages: replica IDs, version vectors, and dot contexts.
+
+Use this package when you are building CRDTs directly or need to track causality for a custom replicated data type. Most application code can install higher-level packages such as `lattice_counters`, `lattice_sets`, or the umbrella `lattice_crdt` package instead.
+
+## Installation
+
+```sh
+gleam add lattice_core
+```
+
+## Quick example
+
+```gleam
+import lattice_core/replica_id
+import lattice_core/version_vector
+
+pub fn main() {
+  let node_a = replica_id.new("node-a")
+  let node_b = replica_id.new("node-b")
+
+  let local =
+    version_vector.new()
+    |> version_vector.increment(node_a)
+
+  let remote =
+    version_vector.new()
+    |> version_vector.increment(node_b)
+
+  version_vector.compare(local, remote)
+  // -> version_vector.Concurrent
+}
+```
+
+## Modules
+
+| Module | Purpose |
+|--------|---------|
+| `lattice_core/replica_id` | Opaque replica identifiers with ordering and JSON helpers. |
+| `lattice_core/version_vector` | Logical clocks for comparing, merging, and serializing causal state. |
+| `lattice_core/dot_context` | Dot sets for observed-remove data structures. |
+
+## Notes
+
+- `VersionVector` supports `increment`, `get`, `compare`, `dominates`, `set_max`, `merge`, `to_json`, and `from_json`.
+- `DotContext` tracks observed dots and supports add, remove, and containment checks.
+- Replica IDs are opaque; create them with `replica_id.new("node-a")`.
+
+## Links
+
+- Project site: <https://lattice.tylerbutler.com>
+- API docs: <https://hexdocs.pm/lattice_core>
+- Hex package: <https://hex.pm/packages/lattice_core>
+- Repository: <https://github.com/tylerbutler/lattice>
+
+## License
+
+MIT

--- a/packages/lattice_counters/README.md
+++ b/packages/lattice_counters/README.md
@@ -1,0 +1,58 @@
+# lattice_counters
+
+Grow-only and positive-negative CRDT counters for Gleam.
+
+Use this package when replicas need to count events independently and merge without coordination. Choose `g_counter` for counters that only increase, or `pn_counter` when values can increase and decrease.
+
+## Installation
+
+```sh
+gleam add lattice_counters
+```
+
+## Quick example
+
+```gleam
+import lattice_core/replica_id
+import lattice_counters/g_counter
+
+pub fn main() {
+  let node_a =
+    g_counter.new(replica_id.new("node-a"))
+    |> g_counter.increment(2)
+
+  let node_b =
+    g_counter.new(replica_id.new("node-b"))
+    |> g_counter.increment(3)
+
+  let merged = g_counter.merge(node_a, node_b)
+
+  g_counter.value(merged)
+  // -> 5
+}
+```
+
+## Modules
+
+| Module | Purpose |
+|--------|---------|
+| `lattice_counters/g_counter` | Grow-only counter. Merges by taking the maximum count per replica. |
+| `lattice_counters/pn_counter` | Positive-negative counter built from two grow-only counters. |
+
+## Notes
+
+- Both counters expose `new`, `merge`, `value`, `to_json`, and `from_json`.
+- Use `increment_with_delta` and `decrement_with_delta` when you want to replicate only the delta from an operation.
+- Deltas must be non-negative. The `try_*` functions return an error for negative deltas; the asserting functions panic if given invalid input.
+- `PNCounter` computes its value as positive counts minus negative counts.
+
+## Links
+
+- Project site: <https://lattice.tylerbutler.com>
+- API docs: <https://hexdocs.pm/lattice_counters>
+- Hex package: <https://hex.pm/packages/lattice_counters>
+- Repository: <https://github.com/tylerbutler/lattice>
+
+## License
+
+MIT

--- a/packages/lattice_crdt/README.md
+++ b/packages/lattice_crdt/README.md
@@ -1,0 +1,55 @@
+# lattice_crdt
+
+Umbrella package for Lattice CRDTs: counters, registers, sets, maps, and causal core types.
+
+Install this package when you want the full Lattice CRDT toolkit. For smaller dependency graphs, install the individual packages directly.
+
+## Installation
+
+```sh
+gleam add lattice_crdt
+```
+
+## Packages included
+
+| Package | Provides |
+|---------|----------|
+| `lattice_core` | Replica IDs, version vectors, and dot contexts. |
+| `lattice_counters` | Grow-only and positive-negative counters. |
+| `lattice_registers` | Last-writer-wins and multi-value registers. |
+| `lattice_sets` | Grow-only, two-phase, and observed-remove sets. |
+| `lattice_maps` | Last-writer-wins maps, observed-remove maps, and CRDT dispatch. |
+
+## Quick example
+
+```gleam
+import lattice_core/replica_id
+import lattice_counters/g_counter
+
+pub fn main() {
+  let counter =
+    g_counter.new(replica_id.new("node-a"))
+    |> g_counter.increment(1)
+
+  g_counter.value(counter)
+  // -> 1
+}
+```
+
+## Notes
+
+- This package reuses the public modules from the individual Lattice packages.
+- Import modules from their package-specific paths, such as `lattice_counters/g_counter` or `lattice_sets/or_set`.
+- All CRDT packages support deterministic merge semantics and JSON serialization.
+- Many mutators also expose delta-state variants for efficient incremental replication.
+
+## Links
+
+- Project site: <https://lattice.tylerbutler.com>
+- API docs: <https://hexdocs.pm/lattice_crdt>
+- Hex package: <https://hex.pm/packages/lattice_crdt>
+- Repository: <https://github.com/tylerbutler/lattice>
+
+## License
+
+MIT

--- a/packages/lattice_maps/README.md
+++ b/packages/lattice_maps/README.md
@@ -1,0 +1,54 @@
+# lattice_maps
+
+Last-writer-wins and observed-remove CRDT maps for Gleam.
+
+Use this package when replicas need key/value data that can be merged without coordination. `lww_map` stores string values with timestamp conflict resolution; `or_map` stores nested CRDT values with observed-remove key semantics.
+
+## Installation
+
+```sh
+gleam add lattice_maps
+```
+
+## Quick example
+
+```gleam
+import lattice_maps/lww_map
+
+pub fn main() {
+  let map =
+    lww_map.new()
+    |> lww_map.set("status", "draft", 1)
+    |> lww_map.set("status", "published", 2)
+
+  lww_map.get(map, "status")
+  // -> Ok("published")
+}
+```
+
+## Modules
+
+| Module | Purpose |
+|--------|---------|
+| `lattice_maps/lww_map` | Last-writer-wins map for string keys and string values. |
+| `lattice_maps/or_map` | Observed-remove map whose values are nested CRDTs. |
+| `lattice_maps/crdt` | Tagged union and specs used by `or_map` to store heterogeneous CRDT values. |
+
+## Notes
+
+- `lww_map` exposes `new`, `set`, `get`, `remove`, `keys`, `values`, `merge`, `prune`, `to_json`, and `from_json`.
+- `or_map` exposes `new`, `update`, `get`, `remove`, `keys`, `values`, `merge`, `prune`, `to_json`, and `from_json`.
+- `or_map.merge` returns a `Result` because maps with incompatible nested CRDT specs cannot be merged.
+- `or_map` supports delta-state replication with `update_with_delta`, `remove_with_delta`, `apply_delta`, `merge_deltas`, `delta_to_json`, and `delta_from_json`.
+- `crdt.CrdtSpec` controls the default nested CRDT created for new keys.
+
+## Links
+
+- Project site: <https://lattice.tylerbutler.com>
+- API docs: <https://hexdocs.pm/lattice_maps>
+- Hex package: <https://hex.pm/packages/lattice_maps>
+- Repository: <https://github.com/tylerbutler/lattice>
+
+## License
+
+MIT

--- a/packages/lattice_presence/README.md
+++ b/packages/lattice_presence/README.md
@@ -1,0 +1,57 @@
+# lattice_presence
+
+Distributed presence CRDT with topic/key/pid/meta tracking, add-wins merge semantics, replica visibility, and Phoenix-style diff reporting.
+
+Use this package to track which users, devices, or processes are online across distributed nodes without requiring a central coordinator.
+
+## Installation
+
+```sh
+gleam add lattice_presence
+```
+
+## Quick example
+
+```gleam
+import gleam/json
+import lattice_presence/presence_state
+
+pub fn main() {
+  let state =
+    presence_state.new("node-a")
+    |> presence_state.join(
+      pid: "pid-1",
+      topic: "room:lobby",
+      key: "alice",
+      meta: json.object([]),
+    )
+
+  presence_state.get_by_topic(state, "room:lobby")
+  // -> [#("pid-1", "alice", json.object([]))]
+}
+```
+
+## Modules
+
+| Module | Purpose |
+|--------|---------|
+| `lattice_presence/presence_state` | Presence CRDT state, joins/leaves, merges, diffs, liveness, and queries. |
+| `lattice_presence/state_json` | JSON encoding and decoding for presence state. |
+
+## Notes
+
+- `presence_state` exposes `new`, `join`, `leave`, `leave_by_pid`, `merge`, `merge_with_diff`, `online_list`, `get_by_topic`, and `get_by_key`.
+- `merge_with_diff` reports Phoenix-style joins and leaves while returning the merged state.
+- Replica liveness is local-only: `replica_down`, `replica_up`, and `remove_down_replica` affect local visibility and are not merged as replicated state.
+- Use `state_json.to_json_string` and `state_json.from_json` for persistence or transport.
+
+## Links
+
+- Project site: <https://lattice.tylerbutler.com>
+- API docs: <https://hexdocs.pm/lattice_presence>
+- Hex package: <https://hex.pm/packages/lattice_presence>
+- Repository: <https://github.com/tylerbutler/lattice>
+
+## License
+
+MIT

--- a/packages/lattice_registers/README.md
+++ b/packages/lattice_registers/README.md
@@ -1,0 +1,54 @@
+# lattice_registers
+
+Last-writer-wins and multi-value CRDT registers for Gleam.
+
+Use this package when replicas need to store a single logical value and resolve concurrent writes deterministically or explicitly expose conflicts.
+
+## Installation
+
+```sh
+gleam add lattice_registers
+```
+
+## Quick example
+
+```gleam
+import lattice_core/replica_id
+import lattice_registers/lww_register
+
+pub fn main() {
+  let node_a = replica_id.new("node-a")
+
+  let register =
+    lww_register.new("draft", 1, node_a)
+    |> lww_register.set("published", 2)
+
+  lww_register.value(register)
+  // -> "published"
+}
+```
+
+## Modules
+
+| Module | Purpose |
+|--------|---------|
+| `lattice_registers/lww_register` | Last-writer-wins register. Higher timestamps win; equal timestamps use replica ID tie-breaking. |
+| `lattice_registers/mv_register` | Multi-value register. Concurrent writes are preserved as multiple values. |
+
+## Notes
+
+- `LWWRegister` exposes `new`, `set`, `set_with_delta`, `merge`, `value`, `to_json`, and `from_json`.
+- `MVRegister` exposes `new`, `set`, `set_with_delta`, `merge`, `value`, `to_json`, and `from_json`.
+- Use `LWWRegister` when a deterministic winner is acceptable.
+- Use `MVRegister` when application code should resolve concurrent writes.
+
+## Links
+
+- Project site: <https://lattice.tylerbutler.com>
+- API docs: <https://hexdocs.pm/lattice_registers>
+- Hex package: <https://hex.pm/packages/lattice_registers>
+- Repository: <https://github.com/tylerbutler/lattice>
+
+## License
+
+MIT

--- a/packages/lattice_sets/README.md
+++ b/packages/lattice_sets/README.md
@@ -1,0 +1,59 @@
+# lattice_sets
+
+Grow-only, two-phase, and observed-remove CRDT sets for Gleam.
+
+Use this package when replicas need set membership that can be merged without coordination. Choose the set type based on whether elements can be removed and later re-added.
+
+## Installation
+
+```sh
+gleam add lattice_sets
+```
+
+## Quick example
+
+```gleam
+import lattice_core/replica_id
+import lattice_sets/or_set
+
+pub fn main() {
+  let node_a =
+    or_set.new(replica_id.new("node-a"))
+    |> or_set.add("alice")
+
+  let node_b =
+    or_set.new(replica_id.new("node-b"))
+    |> or_set.add("bob")
+
+  let merged = or_set.merge(node_a, node_b)
+
+  or_set.contains(merged, "alice")
+  // -> True
+}
+```
+
+## Modules
+
+| Module | Purpose |
+|--------|---------|
+| `lattice_sets/g_set` | Grow-only set. Elements can be added but never removed. |
+| `lattice_sets/two_p_set` | Two-phase set. Elements can be removed once and cannot be re-added. |
+| `lattice_sets/or_set` | Observed-remove set. Elements can be added, removed, and re-added. |
+
+## Notes
+
+- All set modules expose `new`, `add`, `contains`, `value`, `merge`, `to_json`, and `from_json`.
+- `two_p_set` and `or_set` also expose remove operations.
+- Delta-state operations are available with `add_with_delta` and `remove_with_delta`.
+- `or_set` also supports `diff`, `merge_with_diff`, `remove_all`, `remove_where`, `remove_with_bound`, and `prune`.
+
+## Links
+
+- Project site: <https://lattice.tylerbutler.com>
+- API docs: <https://hexdocs.pm/lattice_sets>
+- Hex package: <https://hex.pm/packages/lattice_sets>
+- Repository: <https://github.com/tylerbutler/lattice>
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- add README.md files for the seven publishable lattice packages
- include package purpose, install commands, examples, module summaries, and links to lattice.tylerbutler.com
- leave lattice_sequence and lattice_text unchanged because they are placeholder directories without gleam.toml

## Test
- just docs