### PR TITLE
ci: harden release publishing

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -10,10 +10,12 @@ permissions:
 
 jobs:
   auto-tag:
-    uses: tylerbutler/actions/.github/workflows/auto-tag.yml@5b210da843bed1c39bc1208d4a66964b488e2b5b # ratchet:tylerbutler/actions/.github/workflows/auto-tag.yml@main
+    uses: tylerbutler/actions/.github/workflows/auto-tag.yml@cc915933b1bf1d3515ce3cf97bb6fac58c10c8ca # ratchet:tylerbutler/actions/.github/workflows/auto-tag.yml@main
     with:
       workspace-file: workspace.toml
       create-release: true
+      wait-for-publish: true
+      publish-workflow-name: Publish
     secrets:
       app-id: ${{ secrets.RELEASE_APP_ID }}
       app-private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Read workspace
         id: ws
-        uses: tylerbutler/actions/read-gleam-workspace@d67948fe17fa338034eb7cff2ef51779992438a3 # ratchet:tylerbutler/actions/read-gleam-workspace@main
+        uses: tylerbutler/actions/read-gleam-workspace@5a20063dd6879bfdd0f94db5c8a03a65a90af1cb # ratchet:tylerbutler/actions/read-gleam-workspace@main
 
       - name: Setup environment
         uses: ./.github/actions/setup
@@ -29,7 +29,7 @@ jobs:
       # replace-path-deps rewrites path dependencies to Hex version ranges
       # derived from each package's gleam.toml before publishing.
       - name: Publish to Hex.pm
-        uses: tylerbutler/actions/gleam-publish@d67948fe17fa338034eb7cff2ef51779992438a3 # ratchet:tylerbutler/actions/gleam-publish@main
+        uses: tylerbutler/actions/gleam-publish@5a20063dd6879bfdd0f94db5c8a03a65a90af1cb # ratchet:tylerbutler/actions/gleam-publish@main
         with:
           packages: ${{ steps.ws.outputs.packages }}
           replace-path-deps: |


### PR DESCRIPTION
## Summary
- pin publish workflow actions to the manifest-fix implementation
- pin auto-tag to the wait-for-publish implementation
- enable serialized release tagging so dependent package tags wait for Publish to succeed

## Test
- git diff --check HEAD~2..HEAD

Supersedes #72.