### PR TITLE
ci: validate only tagged package on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Publish
 
 # Broad tag pattern so new packages added to workspace.toml are automatically
-# publishable without editing this workflow. Safe because gleam-publish skips
-# versions already on Hex and only publishes packages listed in workspace.toml.
+# publishable without editing this workflow. The workspace reader maps the tag
+# to a known package path before validation or publish runs.
 on:
   push:
     tags:
@@ -10,11 +10,9 @@ on:
 
 jobs:
   test:
-    uses: ./.github/workflows/ci.yml
-
-  publish:
-    needs: test
     runs-on: ubuntu-latest
+    outputs:
+      package-path: ${{ steps.ws.outputs.tag-package-path }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 
@@ -26,6 +24,30 @@ jobs:
 
       - name: Setup environment
         uses: ./.github/actions/setup
+        with:
+          node: "true"
+
+      - name: Validate tagged package
+        env:
+          PACKAGE: ${{ steps.ws.outputs.tag-package-path }}
+        run: |
+          cd "$PACKAGE"
+          gleam deps download
+          gleam format --check src test
+          gleam check
+          gleam build --warnings-as-errors
+          gleam test
+          gleam test --target javascript
+          gleam docs build
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+
+      - name: Setup environment
+        uses: ./.github/actions/setup
 
       # Publish only the package named by the pushed tag.
       # replace-path-deps rewrites path dependencies to Hex version ranges
@@ -33,7 +55,7 @@ jobs:
       - name: Publish to Hex.pm
         uses: tylerbutler/actions/gleam-publish@f3a3a7d38466a1407c7965872f20e9e8157c11f1 # ratchet:tylerbutler/actions/gleam-publish@main
         with:
-          packages: ${{ steps.ws.outputs.tag-package-path }}
+          packages: ${{ needs.test.outputs.package-path }}
           replace-path-deps: |
             lattice_core:packages/lattice_core/gleam.toml
             lattice_counters:packages/lattice_counters/gleam.toml


### PR DESCRIPTION
## Summary
- replace full workspace CI in Publish with tag-scoped validation
- run format/check/build/docs and Erlang + JavaScript tests only for the tagged package
- pass the validated tag package path into gleam-publish

## Test
- bash scripts/test-publish-workflow.sh (local-only, not committed)
- git diff --check .github/workflows/publish.yml scripts/test-publish-workflow.sh