### PR TITLE
feat(website): add tinylytics analytics

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -27,6 +27,9 @@ export default defineConfig({
 				src: "./src/assets/lattice-min.webp",
 				alt: "lattice logo",
 			},
+			components: {
+				Head: "./src/components/Head.astro",
+			},
 			customCss: [
 				"@fontsource/metropolis/400.css",
 				"@fontsource/metropolis/600.css",

--- a/website/package.json
+++ b/website/package.json
@@ -26,6 +26,7 @@
 		"@fontsource/metropolis": "^5.2.5",
 		"astro": "^6.1.4",
 		"astro-mermaid": "^2.0.1",
+		"astro-tinylytics": "^0.1.0",
 		"mermaid": "^11.14.0",
 		"sharp": "^0.34.5",
 		"starlight-links-validator": "^0.22.0",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       astro-mermaid:
         specifier: ^2.0.1
         version: 2.0.1(astro@6.1.4(@types/node@24.12.2)(rollup@4.59.0)(typescript@6.0.2)(yaml@2.8.3))(mermaid@11.14.0)
+      astro-tinylytics:
+        specifier: ^0.1.0
+        version: 0.1.0(astro@6.1.4(@types/node@24.12.2)(rollup@4.59.0)(typescript@6.0.2)(yaml@2.8.3))
       mermaid:
         specifier: ^11.14.0
         version: 11.14.0
@@ -1008,6 +1011,12 @@ packages:
     peerDependenciesMeta:
       '@mermaid-js/layout-elk':
         optional: true
+
+  astro-tinylytics@0.1.0:
+    resolution: {integrity: sha512-TK/Ang0suanYCukxt0kzigam2BJBjWQsksD1YgRCb1931/pjMgHXej5YIJSD3LgcKfzIlDR0bnJobZ2NDY9tKA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      astro: '>=4.0.0'
 
   astro@6.1.4:
     resolution: {integrity: sha512-SRy1bONuCHkGWhI5JiWCQKVDVbeaXOikjAVZs/Nz+lvUvubtdLoZfnacmuZHQ9RL2IOkU54M8/qZYm9ypJDKrg==}
@@ -3625,6 +3634,10 @@ snapshots:
       mdast-util-to-string: 4.0.0
       mermaid: 11.14.0
       unist-util-visit: 5.1.0
+
+  astro-tinylytics@0.1.0(astro@6.1.4(@types/node@24.12.2)(rollup@4.59.0)(typescript@6.0.2)(yaml@2.8.3)):
+    dependencies:
+      astro: 6.1.4(@types/node@24.12.2)(rollup@4.59.0)(typescript@6.0.2)(yaml@2.8.3)
 
   astro@6.1.4(@types/node@24.12.2)(rollup@4.59.0)(typescript@6.0.2)(yaml@2.8.3):
     dependencies:

--- a/website/src/components/Head.astro
+++ b/website/src/components/Head.astro
@@ -1,0 +1,6 @@
+---
+import Default from "@astrojs/starlight/components/Head.astro";
+import { Script } from "astro-tinylytics";
+---
+<Default><slot /></Default>
+<Script embedCode="Paa4zWGQsDwpbtea8HP3" min hits events beacon />


### PR DESCRIPTION
## Summary

Adds [Tinylytics](https://tinylytics.app/) analytics to the documentation website.

## Changes

- Installed `astro-tinylytics` in `website/`.
- Added a Starlight `Head` slot override at `website/src/components/Head.astro` that wraps the default head and injects the Tinylytics `<Script>`.
- Registered the override under `components.Head` in `website/astro.config.mjs`.

## Configuration

Script flags enabled: `min hits events beacon`

- `hits` — page-view counter
- `events` + `beacon` — click/event tracking that survives navigation
- `min` — minified embed build

The embed code is inlined (it is a public site identifier, not a secret).

## Validation

- `pnpm check:astro` → 0 errors, 0 warnings, 0 hints
