### PR TITLE
build: set up glinter linting across the workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,21 @@ jobs:
       cache: true
       check: true
 
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup environment
+        uses: tylerbutler/actions/setup-gleam@v1
+
+      - name: Download dependencies
+        run: just deps
+
+      - name: Lint (glinter)
+        run: just lint
+
   build:
     name: Build
     uses: tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@d67948fe17fa338034eb7cff2ef51779992438a3 # ratchet:tylerbutler/actions/.github/workflows/gleam-workspace-ci.yml@main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,8 @@ just test-pkg <name>   # Test a single package
 just format            # Format code
 just format-check      # Check formatting
 just check             # Type check all packages
+just lint              # Lint all packages + examples (glinter)
+just lint-pkg <name>   # Lint a single package
 just docs              # Build documentation
 just ci                # Run all CI checks (format, check, test, build)
 just pr                # Alias for ci (use before PR)

--- a/examples/gleam.toml
+++ b/examples/gleam.toml
@@ -11,3 +11,26 @@ lattice_sets = { path = "../packages/lattice_sets" }
 lattice_maps = { path = "../packages/lattice_maps" }
 gleam_stdlib = ">= 0.48.0 and < 2.0.0"
 gleam_json = ">= 3.1.0 and < 4.0.0"
+
+[dev-dependencies]
+glinter = ">= 2.19.0 and < 3.0.0"
+
+[tools.glinter]
+include = ["src/"]
+warnings_as_errors = true
+
+[tools.glinter.rules]
+# Demonstration code favours brevity: round-trip examples handle decode
+# failures by printing a message, and `let assert` keeps sample code short.
+thrown_away_error = "off"
+assert_ok_pattern = "off"
+# Stylistic rules the codebase intentionally does not follow.
+label_possible = "off"
+missing_labels = "off"
+short_variable_name = "off"
+missing_type_annotation = "off"
+unnecessary_variable = "off"
+prefer_guard_clause = "off"
+deep_nesting = "off"
+trailing_underscore = "off"
+unqualified_import = "off"

--- a/examples/gleam.toml
+++ b/examples/gleam.toml
@@ -21,16 +21,11 @@ warnings_as_errors = true
 
 [tools.glinter.rules]
 # Demonstration code favours brevity: round-trip examples handle decode
-# failures by printing a message, and `let assert` keeps sample code short.
+# failures by printing a message, `let assert` keeps sample code short,
+# `main` entrypoints skip return annotations, and short loop names are fine.
 thrown_away_error = "off"
 assert_ok_pattern = "off"
+missing_type_annotation = "off"
+short_variable_name = "off"
 # Stylistic rules the codebase intentionally does not follow.
 label_possible = "off"
-missing_labels = "off"
-short_variable_name = "off"
-missing_type_annotation = "off"
-unnecessary_variable = "off"
-prefer_guard_clause = "off"
-deep_nesting = "off"
-trailing_underscore = "off"
-unqualified_import = "off"

--- a/examples/manifest.toml
+++ b/examples/manifest.toml
@@ -2,19 +2,29 @@
 # You typically do not need to edit this file
 
 packages = [
+  { name = "argv", version = "1.1.0", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "3277D100448BDB4A29B6D58C0F36F631CBC349E8BDD09766C6309DF202831140" },
+  { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
   { name = "gleam_json", version = "3.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "44FDAA8847BE8FC48CA7A1C089706BD54BADCC4C45B237A992EDDF9F2CDB2836" },
-  { name = "gleam_stdlib", version = "0.71.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "702F3BC2A14793906880B1078B19A6165F87323AEE8D0C4A34085846336FCAAE" },
-  { name = "lattice_core", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], source = "local", path = "../packages/lattice_core" },
-  { name = "lattice_counters", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core"], source = "local", path = "../packages/lattice_counters" },
-  { name = "lattice_crdt", version = "0.1.0", build_tools = ["gleam"], requirements = ["lattice_core", "lattice_counters", "lattice_maps", "lattice_registers", "lattice_sets"], source = "local", path = "../packages/lattice_crdt" },
-  { name = "lattice_maps", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core", "lattice_counters", "lattice_registers", "lattice_sets"], source = "local", path = "../packages/lattice_maps" },
-  { name = "lattice_registers", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core"], source = "local", path = "../packages/lattice_registers" },
-  { name = "lattice_sets", version = "0.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core"], source = "local", path = "../packages/lattice_sets" },
+  { name = "gleam_stdlib", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "0C5506589DF4C63DF5D6FFBB834562D6865C6C2AEE0019D7B37886BD6D128141" },
+  { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
+  { name = "glinter", version = "2.19.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "9A0B5EE224BB84FB25DFB4A8DD3E87F06BDFE0C49B3A669D92AB4C555593FC75" },
+  { name = "lattice_core", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], source = "local", path = "../packages/lattice_core" },
+  { name = "lattice_counters", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core"], source = "local", path = "../packages/lattice_counters" },
+  { name = "lattice_crdt", version = "2.1.0", build_tools = ["gleam"], requirements = ["lattice_core", "lattice_counters", "lattice_maps", "lattice_registers", "lattice_sets"], source = "local", path = "../packages/lattice_crdt" },
+  { name = "lattice_maps", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core", "lattice_counters", "lattice_registers", "lattice_sets"], source = "local", path = "../packages/lattice_maps" },
+  { name = "lattice_registers", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core"], source = "local", path = "../packages/lattice_registers" },
+  { name = "lattice_sets", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core"], source = "local", path = "../packages/lattice_sets" },
+  { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
+  { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
+  { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 
 [requirements]
 gleam_json = { version = ">= 3.1.0 and < 4.0.0" }
 gleam_stdlib = { version = ">= 0.48.0 and < 2.0.0" }
+glinter = { version = ">= 2.19.0 and < 3.0.0" }
 lattice_core = { path = "../packages/lattice_core" }
 lattice_counters = { path = "../packages/lattice_counters" }
 lattice_crdt = { path = "../packages/lattice_crdt" }

--- a/justfile
+++ b/justfile
@@ -89,6 +89,17 @@ check:
         ( cd packages/$pkg && gleam check )
     done
 
+# Lint all packages and examples with glinter (config in each gleam.toml)
+lint:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for pkg in {{ packages }}; do
+        echo "==> $pkg: lint"
+        ( cd packages/$pkg && gleam run -m glinter )
+    done
+    echo "==> examples: lint"
+    ( cd examples && gleam run -m glinter )
+
 # === DOCUMENTATION ===
 
 # Build documentation for all packages
@@ -135,6 +146,10 @@ clean:
 test-pkg pkg:
     cd packages/{{ pkg }} && gleam test
 
+# Lint a single package: just lint-pkg lattice_core
+lint-pkg pkg:
+    cd packages/{{ pkg }} && gleam run -m glinter
+
 # Build a single package: just build-pkg lattice_core
 build-pkg pkg:
     cd packages/{{ pkg }} && gleam build
@@ -172,8 +187,8 @@ examples: examples-run examples-run-js
 
 # === CI ===
 
-# Run all CI checks (format, check, test, build strict)
-ci: format-check check test build-strict
+# Run all CI checks (format, check, lint, test, build strict)
+ci: format-check check lint test build-strict
 
 # Alias for PR checks
 alias pr := ci

--- a/packages/lattice_core/gleam.toml
+++ b/packages/lattice_core/gleam.toml
@@ -11,3 +11,30 @@ gleam_json = ">= 3.1.0 and < 4.0.0"
 
 [dev-dependencies]
 startest = ">= 0.8.0 and < 1.0.0"
+glinter = ">= 2.19.0 and < 3.0.0"
+
+[tools.glinter]
+include = ["src/", "test/"]
+# warnings_as_errors makes every *enabled* rule fail CI. Rules we don't want
+# to enforce are turned off below; tests get a lenient profile in [ignore].
+warnings_as_errors = true
+
+[tools.glinter.rules]
+# Library public API is consumed externally, so "never used in this package"
+# is expected — not an issue.
+unused_exports = "off"
+# Stylistic rules the codebase intentionally does not follow.
+label_possible = "off"
+missing_labels = "off"
+short_variable_name = "off"
+missing_type_annotation = "off"
+unnecessary_variable = "off"
+prefer_guard_clause = "off"
+deep_nesting = "off"
+trailing_underscore = "off"
+unqualified_import = "off"
+
+[tools.glinter.ignore]
+# Tests use `let assert Ok(...)`, discard errors, and panic in unreachable
+# match arms by convention; these substantive rules apply to src/ only.
+"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic"]

--- a/packages/lattice_core/gleam.toml
+++ b/packages/lattice_core/gleam.toml
@@ -15,26 +15,18 @@ glinter = ">= 2.19.0 and < 3.0.0"
 
 [tools.glinter]
 include = ["src/", "test/"]
-# warnings_as_errors makes every *enabled* rule fail CI. Rules we don't want
-# to enforce are turned off below; tests get a lenient profile in [ignore].
+# warnings_as_errors makes every *enabled* rule fail CI, so the few rules we
+# don't enforce are turned off below; tests get a lenient profile in [ignore].
 warnings_as_errors = true
 
 [tools.glinter.rules]
 # Library public API is consumed externally, so "never used in this package"
 # is expected — not an issue.
 unused_exports = "off"
-# Stylistic rules the codebase intentionally does not follow.
+# The codebase intentionally does not use argument labels.
 label_possible = "off"
-missing_labels = "off"
-short_variable_name = "off"
-missing_type_annotation = "off"
-unnecessary_variable = "off"
-prefer_guard_clause = "off"
-deep_nesting = "off"
-trailing_underscore = "off"
-unqualified_import = "off"
-
 [tools.glinter.ignore]
-# Tests use `let assert Ok(...)`, discard errors, and panic in unreachable
-# match arms by convention; these substantive rules apply to src/ only.
-"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic"]
+# Tests use `let assert Ok(...)`, discard errors, panic in unreachable match
+# arms, and skip return-type annotations by convention; these rules apply to
+# src/ only.
+"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic", "missing_type_annotation", "short_variable_name"]

--- a/packages/lattice_core/manifest.toml
+++ b/packages/lattice_core/manifest.toml
@@ -6,6 +6,7 @@ packages = [
   { name = "bigben", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time", "interior"], otp_app = "bigben", source = "hex", outer_checksum = "4B0D9F2514C06AE577F284532270A6F89007781620E4B12A843388BA549C17D2" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
   { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
   { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
@@ -15,10 +16,13 @@ packages = [
   { name = "gleam_regexp", version = "1.1.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_regexp", source = "hex", outer_checksum = "9C215C6CA84A5B35BB934A9B61A9A306EC743153BE2B0425A0D032E477B062A9" },
   { name = "gleam_stdlib", version = "0.70.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86949BF5D1F0E4AC0AB5B06F235D8A5CC11A2DFC33BF22F752156ED61CA7D0FF" },
   { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
+  { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
+  { name = "glinter", version = "2.19.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "9A0B5EE224BB84FB25DFB4A8DD3E87F06BDFE0C49B3A669D92AB4C555593FC75" },
   { name = "interior", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "interior", source = "hex", outer_checksum = "EE2728791E34400CB3CD986B6AD0E02A2F970F50B5ED59896E2820702C7DDD29" },
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
   { name = "tom", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "234A842F3D087D35737483F5DFB6DE9839E3366EF0CAF8726D2D094210227670" },
 ]
@@ -26,4 +30,5 @@ packages = [
 [requirements]
 gleam_json = { version = ">= 3.1.0 and < 4.0.0" }
 gleam_stdlib = { version = ">= 0.48.0 and < 2.0.0" }
+glinter = { version = ">= 2.19.0 and < 3.0.0" }
 startest = { version = ">= 0.8.0 and < 1.0.0" }

--- a/packages/lattice_core/src/lattice_core/dot_context.gleam
+++ b/packages/lattice_core/src/lattice_core/dot_context.gleam
@@ -54,9 +54,9 @@ pub fn new() -> DotContext {
 /// Records that the event `(replica_id, counter)` has been observed. If the
 /// dot is already present, the context is returned unchanged.
 pub fn add_dot(
-  context: DotContext,
-  replica_id: ReplicaId,
-  counter: Int,
+  context context: DotContext,
+  replica_id replica_id: ReplicaId,
+  counter counter: Int,
 ) -> DotContext {
   DotContext(dots: set.insert(context.dots, Dot(replica_id:, counter:)))
 }

--- a/packages/lattice_core/src/lattice_core/version_vector.gleam
+++ b/packages/lattice_core/src/lattice_core/version_vector.gleam
@@ -139,9 +139,9 @@ pub fn is_empty(vv: VersionVector) -> Bool {
 /// If the replica has no entry, `value` is used. This avoids round-tripping
 /// through `to_dict`/`from_dict` when building a version vector incrementally.
 pub fn set_max(
-  vv: VersionVector,
-  replica_id: ReplicaId,
-  value: Int,
+  vv vv: VersionVector,
+  replica_id replica_id: ReplicaId,
+  value value: Int,
 ) -> VersionVector {
   let VersionVector(d) = vv
   let current = result.unwrap(dict.get(d, replica_id), 0)

--- a/packages/lattice_counters/gleam.toml
+++ b/packages/lattice_counters/gleam.toml
@@ -13,3 +13,30 @@ lattice_core = { path = "../lattice_core" }
 [dev-dependencies]
 startest = ">= 0.8.0 and < 1.0.0"
 qcheck = ">= 1.0.0 and < 2.0.0"
+glinter = ">= 2.19.0 and < 3.0.0"
+
+[tools.glinter]
+include = ["src/", "test/"]
+# warnings_as_errors makes every *enabled* rule fail CI. Rules we don't want
+# to enforce are turned off below; tests get a lenient profile in [ignore].
+warnings_as_errors = true
+
+[tools.glinter.rules]
+# Library public API is consumed externally, so "never used in this package"
+# is expected — not an issue.
+unused_exports = "off"
+# Stylistic rules the codebase intentionally does not follow.
+label_possible = "off"
+missing_labels = "off"
+short_variable_name = "off"
+missing_type_annotation = "off"
+unnecessary_variable = "off"
+prefer_guard_clause = "off"
+deep_nesting = "off"
+trailing_underscore = "off"
+unqualified_import = "off"
+
+[tools.glinter.ignore]
+# Tests use `let assert Ok(...)`, discard errors, and panic in unreachable
+# match arms by convention; these substantive rules apply to src/ only.
+"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic"]

--- a/packages/lattice_counters/gleam.toml
+++ b/packages/lattice_counters/gleam.toml
@@ -17,26 +17,18 @@ glinter = ">= 2.19.0 and < 3.0.0"
 
 [tools.glinter]
 include = ["src/", "test/"]
-# warnings_as_errors makes every *enabled* rule fail CI. Rules we don't want
-# to enforce are turned off below; tests get a lenient profile in [ignore].
+# warnings_as_errors makes every *enabled* rule fail CI, so the few rules we
+# don't enforce are turned off below; tests get a lenient profile in [ignore].
 warnings_as_errors = true
 
 [tools.glinter.rules]
 # Library public API is consumed externally, so "never used in this package"
 # is expected — not an issue.
 unused_exports = "off"
-# Stylistic rules the codebase intentionally does not follow.
+# The codebase intentionally does not use argument labels.
 label_possible = "off"
-missing_labels = "off"
-short_variable_name = "off"
-missing_type_annotation = "off"
-unnecessary_variable = "off"
-prefer_guard_clause = "off"
-deep_nesting = "off"
-trailing_underscore = "off"
-unqualified_import = "off"
-
 [tools.glinter.ignore]
-# Tests use `let assert Ok(...)`, discard errors, and panic in unreachable
-# match arms by convention; these substantive rules apply to src/ only.
-"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic"]
+# Tests use `let assert Ok(...)`, discard errors, panic in unreachable match
+# arms, and skip return-type annotations by convention; these rules apply to
+# src/ only.
+"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic", "missing_type_annotation", "short_variable_name"]

--- a/packages/lattice_counters/manifest.toml
+++ b/packages/lattice_counters/manifest.toml
@@ -6,6 +6,7 @@ packages = [
   { name = "bigben", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time", "interior"], otp_app = "bigben", source = "hex", outer_checksum = "4B0D9F2514C06AE577F284532270A6F89007781620E4B12A843388BA549C17D2" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
   { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
   { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
@@ -16,13 +17,16 @@ packages = [
   { name = "gleam_stdlib", version = "0.71.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "702F3BC2A14793906880B1078B19A6165F87323AEE8D0C4A34085846336FCAAE" },
   { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
+  { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
+  { name = "glinter", version = "2.19.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "9A0B5EE224BB84FB25DFB4A8DD3E87F06BDFE0C49B3A669D92AB4C555593FC75" },
   { name = "interior", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "interior", source = "hex", outer_checksum = "EE2728791E34400CB3CD986B6AD0E02A2F970F50B5ED59896E2820702C7DDD29" },
   { name = "lattice_core", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], source = "local", path = "../lattice_core" },
   { name = "prng", version = "5.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "prng", source = "hex", outer_checksum = "29DA88BCFB54D06DD1472951DF101E9524878056D139DA2616B04350B403CE10" },
   { name = "qcheck", version = "1.0.4", build_tools = ["gleam"], requirements = ["exception", "gleam_regexp", "gleam_stdlib", "gleam_yielder", "prng"], otp_app = "qcheck", source = "hex", outer_checksum = "BD9B18C1602FBC667E3E139ED270458F8C743ED791F892CC90989CE10478C4FA" },
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
   { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
@@ -30,6 +34,7 @@ packages = [
 [requirements]
 gleam_json = { version = ">= 3.1.0 and < 4.0.0" }
 gleam_stdlib = { version = ">= 0.48.0 and < 2.0.0" }
+glinter = { version = ">= 2.19.0 and < 3.0.0" }
 lattice_core = { path = "../lattice_core" }
 qcheck = { version = ">= 1.0.0 and < 2.0.0" }
 startest = { version = ">= 0.8.0 and < 1.0.0" }

--- a/packages/lattice_counters/src/lattice_counters/g_counter.gleam
+++ b/packages/lattice_counters/src/lattice_counters/g_counter.gleam
@@ -56,6 +56,9 @@ pub fn new(replica_id: ReplicaId) -> GCounter {
 /// See `increment_with_delta` for the delta-state variant that also returns
 /// a small payload suitable for incremental sync (e.g. over websockets).
 pub fn increment(counter: GCounter, delta: Int) -> GCounter {
+  // Ergonomic wrapper documented to panic on a negative delta; callers
+  // needing error handling use `try_increment`.
+  // nolint: assert_ok_pattern
   let assert Ok(updated) = try_increment(counter, delta)
   updated
 }
@@ -88,6 +91,9 @@ pub fn increment_with_delta(
   counter: GCounter,
   delta: Int,
 ) -> #(GCounter, GCounter) {
+  // Ergonomic wrapper documented to panic on a negative delta; callers
+  // needing error handling use `try_increment_with_delta`.
+  // nolint: assert_ok_pattern
   let assert Ok(result) = try_increment_with_delta(counter, delta)
   result
 }

--- a/packages/lattice_counters/src/lattice_counters/g_counter.gleam
+++ b/packages/lattice_counters/src/lattice_counters/g_counter.gleam
@@ -19,6 +19,7 @@
 //// g_counter.value(merged)  // -> 8
 //// ```
 
+import gleam/bool
 import gleam/dict
 import gleam/dynamic/decode
 import gleam/int
@@ -107,18 +108,13 @@ pub fn try_increment_with_delta(
   counter: GCounter,
   delta: Int,
 ) -> Result(#(GCounter, GCounter), IncrementError) {
-  case delta < 0 {
-    True -> Error(NegativeDelta(delta))
-    False -> {
-      let GCounter(dict, self_id) = counter
-      let current = result.unwrap(dict.get(dict, self_id), 0)
-      let new_count = current + delta
-      let updated = GCounter(dict.insert(dict, self_id, new_count), self_id)
-      let delta_state =
-        GCounter(dict.from_list([#(self_id, new_count)]), self_id)
-      Ok(#(updated, delta_state))
-    }
-  }
+  use <- bool.guard(delta < 0, Error(NegativeDelta(delta)))
+  let GCounter(dict, self_id) = counter
+  let current = result.unwrap(dict.get(dict, self_id), 0)
+  let new_count = current + delta
+  let updated = GCounter(dict.insert(dict, self_id, new_count), self_id)
+  let delta_state = GCounter(dict.from_list([#(self_id, new_count)]), self_id)
+  Ok(#(updated, delta_state))
 }
 
 /// Get the current value of the counter.

--- a/packages/lattice_counters/src/lattice_counters/pn_counter.gleam
+++ b/packages/lattice_counters/src/lattice_counters/pn_counter.gleam
@@ -55,6 +55,9 @@ pub fn new(replica_id: ReplicaId) -> PNCounter {
 /// See `increment_with_delta` for the delta-state variant that also returns
 /// a small payload suitable for incremental sync (e.g. over websockets).
 pub fn increment(counter: PNCounter, delta: Int) -> PNCounter {
+  // Ergonomic wrapper documented to panic on a negative delta; callers
+  // needing error handling use `try_increment`.
+  // nolint: assert_ok_pattern
   let assert Ok(updated) = try_increment(counter, delta)
   updated
 }
@@ -84,6 +87,9 @@ pub fn increment_with_delta(
   counter: PNCounter,
   delta: Int,
 ) -> #(PNCounter, PNCounter) {
+  // Ergonomic wrapper documented to panic on a negative delta; callers
+  // needing error handling use `try_increment_with_delta`.
+  // nolint: assert_ok_pattern
   let assert Ok(result) = try_increment_with_delta(counter, delta)
   result
 }
@@ -118,6 +124,9 @@ pub fn try_increment_with_delta(
 ///
 /// See `decrement_with_delta` for the delta-state variant.
 pub fn decrement(counter: PNCounter, delta: Int) -> PNCounter {
+  // Ergonomic wrapper documented to panic on a negative delta; callers
+  // needing error handling use `try_decrement`.
+  // nolint: assert_ok_pattern
   let assert Ok(updated) = try_decrement(counter, delta)
   updated
 }
@@ -147,6 +156,9 @@ pub fn decrement_with_delta(
   counter: PNCounter,
   delta: Int,
 ) -> #(PNCounter, PNCounter) {
+  // Ergonomic wrapper documented to panic on a negative delta; callers
+  // needing error handling use `try_decrement_with_delta`.
+  // nolint: assert_ok_pattern
   let assert Ok(result) = try_decrement_with_delta(counter, delta)
   result
 }

--- a/packages/lattice_crdt/gleam.toml
+++ b/packages/lattice_crdt/gleam.toml
@@ -15,3 +15,30 @@ lattice_maps = { path = "../lattice_maps" }
 [dev-dependencies]
 startest = ">= 0.8.0 and < 1.0.0"
 qcheck = ">= 1.0.0 and < 2.0.0"
+glinter = ">= 2.19.0 and < 3.0.0"
+
+[tools.glinter]
+include = ["src/", "test/"]
+# warnings_as_errors makes every *enabled* rule fail CI. Rules we don't want
+# to enforce are turned off below; tests get a lenient profile in [ignore].
+warnings_as_errors = true
+
+[tools.glinter.rules]
+# Library public API is consumed externally, so "never used in this package"
+# is expected — not an issue.
+unused_exports = "off"
+# Stylistic rules the codebase intentionally does not follow.
+label_possible = "off"
+missing_labels = "off"
+short_variable_name = "off"
+missing_type_annotation = "off"
+unnecessary_variable = "off"
+prefer_guard_clause = "off"
+deep_nesting = "off"
+trailing_underscore = "off"
+unqualified_import = "off"
+
+[tools.glinter.ignore]
+# Tests use `let assert Ok(...)`, discard errors, and panic in unreachable
+# match arms by convention; these substantive rules apply to src/ only.
+"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic"]

--- a/packages/lattice_crdt/gleam.toml
+++ b/packages/lattice_crdt/gleam.toml
@@ -19,26 +19,18 @@ glinter = ">= 2.19.0 and < 3.0.0"
 
 [tools.glinter]
 include = ["src/", "test/"]
-# warnings_as_errors makes every *enabled* rule fail CI. Rules we don't want
-# to enforce are turned off below; tests get a lenient profile in [ignore].
+# warnings_as_errors makes every *enabled* rule fail CI, so the few rules we
+# don't enforce are turned off below; tests get a lenient profile in [ignore].
 warnings_as_errors = true
 
 [tools.glinter.rules]
 # Library public API is consumed externally, so "never used in this package"
 # is expected — not an issue.
 unused_exports = "off"
-# Stylistic rules the codebase intentionally does not follow.
+# The codebase intentionally does not use argument labels.
 label_possible = "off"
-missing_labels = "off"
-short_variable_name = "off"
-missing_type_annotation = "off"
-unnecessary_variable = "off"
-prefer_guard_clause = "off"
-deep_nesting = "off"
-trailing_underscore = "off"
-unqualified_import = "off"
-
 [tools.glinter.ignore]
-# Tests use `let assert Ok(...)`, discard errors, and panic in unreachable
-# match arms by convention; these substantive rules apply to src/ only.
-"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic"]
+# Tests use `let assert Ok(...)`, discard errors, panic in unreachable match
+# arms, and skip return-type annotations by convention; these rules apply to
+# src/ only.
+"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic", "missing_type_annotation", "short_variable_name"]

--- a/packages/lattice_crdt/manifest.toml
+++ b/packages/lattice_crdt/manifest.toml
@@ -6,6 +6,7 @@ packages = [
   { name = "bigben", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time", "interior"], otp_app = "bigben", source = "hex", outer_checksum = "4B0D9F2514C06AE577F284532270A6F89007781620E4B12A843388BA549C17D2" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
   { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
   { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
@@ -16,7 +17,9 @@ packages = [
   { name = "gleam_stdlib", version = "0.71.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "702F3BC2A14793906880B1078B19A6165F87323AEE8D0C4A34085846336FCAAE" },
   { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
+  { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
+  { name = "glinter", version = "2.19.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "9A0B5EE224BB84FB25DFB4A8DD3E87F06BDFE0C49B3A669D92AB4C555593FC75" },
   { name = "interior", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "interior", source = "hex", outer_checksum = "EE2728791E34400CB3CD986B6AD0E02A2F970F50B5ED59896E2820702C7DDD29" },
   { name = "lattice_core", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], source = "local", path = "../lattice_core" },
   { name = "lattice_counters", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core"], source = "local", path = "../lattice_counters" },
@@ -27,11 +30,13 @@ packages = [
   { name = "qcheck", version = "1.0.4", build_tools = ["gleam"], requirements = ["exception", "gleam_regexp", "gleam_stdlib", "gleam_yielder", "prng"], otp_app = "qcheck", source = "hex", outer_checksum = "BD9B18C1602FBC667E3E139ED270458F8C743ED791F892CC90989CE10478C4FA" },
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
   { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
 
 [requirements]
+glinter = { version = ">= 2.19.0 and < 3.0.0" }
 lattice_core = { path = "../lattice_core" }
 lattice_counters = { path = "../lattice_counters" }
 lattice_maps = { path = "../lattice_maps" }

--- a/packages/lattice_maps/gleam.toml
+++ b/packages/lattice_maps/gleam.toml
@@ -16,3 +16,30 @@ lattice_sets = { path = "../lattice_sets" }
 [dev-dependencies]
 startest = ">= 0.8.0 and < 1.0.0"
 qcheck = ">= 1.0.0 and < 2.0.0"
+glinter = ">= 2.19.0 and < 3.0.0"
+
+[tools.glinter]
+include = ["src/", "test/"]
+# warnings_as_errors makes every *enabled* rule fail CI. Rules we don't want
+# to enforce are turned off below; tests get a lenient profile in [ignore].
+warnings_as_errors = true
+
+[tools.glinter.rules]
+# Library public API is consumed externally, so "never used in this package"
+# is expected — not an issue.
+unused_exports = "off"
+# Stylistic rules the codebase intentionally does not follow.
+label_possible = "off"
+missing_labels = "off"
+short_variable_name = "off"
+missing_type_annotation = "off"
+unnecessary_variable = "off"
+prefer_guard_clause = "off"
+deep_nesting = "off"
+trailing_underscore = "off"
+unqualified_import = "off"
+
+[tools.glinter.ignore]
+# Tests use `let assert Ok(...)`, discard errors, and panic in unreachable
+# match arms by convention; these substantive rules apply to src/ only.
+"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic"]

--- a/packages/lattice_maps/gleam.toml
+++ b/packages/lattice_maps/gleam.toml
@@ -20,26 +20,18 @@ glinter = ">= 2.19.0 and < 3.0.0"
 
 [tools.glinter]
 include = ["src/", "test/"]
-# warnings_as_errors makes every *enabled* rule fail CI. Rules we don't want
-# to enforce are turned off below; tests get a lenient profile in [ignore].
+# warnings_as_errors makes every *enabled* rule fail CI, so the few rules we
+# don't enforce are turned off below; tests get a lenient profile in [ignore].
 warnings_as_errors = true
 
 [tools.glinter.rules]
 # Library public API is consumed externally, so "never used in this package"
 # is expected — not an issue.
 unused_exports = "off"
-# Stylistic rules the codebase intentionally does not follow.
+# The codebase intentionally does not use argument labels.
 label_possible = "off"
-missing_labels = "off"
-short_variable_name = "off"
-missing_type_annotation = "off"
-unnecessary_variable = "off"
-prefer_guard_clause = "off"
-deep_nesting = "off"
-trailing_underscore = "off"
-unqualified_import = "off"
-
 [tools.glinter.ignore]
-# Tests use `let assert Ok(...)`, discard errors, and panic in unreachable
-# match arms by convention; these substantive rules apply to src/ only.
-"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic"]
+# Tests use `let assert Ok(...)`, discard errors, panic in unreachable match
+# arms, and skip return-type annotations by convention; these rules apply to
+# src/ only.
+"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic", "missing_type_annotation", "short_variable_name"]

--- a/packages/lattice_maps/manifest.toml
+++ b/packages/lattice_maps/manifest.toml
@@ -6,6 +6,7 @@ packages = [
   { name = "bigben", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time", "interior"], otp_app = "bigben", source = "hex", outer_checksum = "4B0D9F2514C06AE577F284532270A6F89007781620E4B12A843388BA549C17D2" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
   { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
   { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
@@ -16,7 +17,9 @@ packages = [
   { name = "gleam_stdlib", version = "0.71.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "702F3BC2A14793906880B1078B19A6165F87323AEE8D0C4A34085846336FCAAE" },
   { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
+  { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
+  { name = "glinter", version = "2.19.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "9A0B5EE224BB84FB25DFB4A8DD3E87F06BDFE0C49B3A669D92AB4C555593FC75" },
   { name = "interior", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "interior", source = "hex", outer_checksum = "EE2728791E34400CB3CD986B6AD0E02A2F970F50B5ED59896E2820702C7DDD29" },
   { name = "lattice_core", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], source = "local", path = "../lattice_core" },
   { name = "lattice_counters", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "lattice_core"], source = "local", path = "../lattice_counters" },
@@ -26,6 +29,7 @@ packages = [
   { name = "qcheck", version = "1.0.4", build_tools = ["gleam"], requirements = ["exception", "gleam_regexp", "gleam_stdlib", "gleam_yielder", "prng"], otp_app = "qcheck", source = "hex", outer_checksum = "BD9B18C1602FBC667E3E139ED270458F8C743ED791F892CC90989CE10478C4FA" },
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
   { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
@@ -33,6 +37,7 @@ packages = [
 [requirements]
 gleam_json = { version = ">= 3.1.0 and < 4.0.0" }
 gleam_stdlib = { version = ">= 0.48.0 and < 2.0.0" }
+glinter = { version = ">= 2.19.0 and < 3.0.0" }
 lattice_core = { path = "../lattice_core" }
 lattice_counters = { path = "../lattice_counters" }
 lattice_registers = { path = "../lattice_registers" }

--- a/packages/lattice_maps/src/lattice_maps/crdt.gleam
+++ b/packages/lattice_maps/src/lattice_maps/crdt.gleam
@@ -161,9 +161,9 @@ pub fn default_delta(spec: CrdtSpec, replica_id: ReplicaId) -> Crdt {
 /// `GCounter` carrying `{self_id: 0}` is structurally distinct from the
 /// fresh empty counter); such cases produce a small but harmless delta.
 pub fn is_empty_delta(
-  value: Crdt,
-  spec: CrdtSpec,
-  replica_id: ReplicaId,
+  value value: Crdt,
+  spec spec: CrdtSpec,
+  replica_id replica_id: ReplicaId,
 ) -> Bool {
   value == default_delta(spec, replica_id)
 }

--- a/packages/lattice_maps/src/lattice_maps/lww_map.gleam
+++ b/packages/lattice_maps/src/lattice_maps/lww_map.gleam
@@ -71,7 +71,7 @@ pub fn pruned_timestamp(map: LWWMap) -> Int {
 /// existing entry is kept (LWW semantics: strictly greater timestamp wins).
 pub fn set(map: LWWMap, key: String, value: String, timestamp: Int) -> LWWMap {
   let should_update = case dict.get(map.entries, key) {
-    Error(_) -> True
+    Error(Nil) -> True
     Ok(#(_, existing_ts)) -> timestamp > existing_ts
   }
   case should_update {
@@ -105,7 +105,7 @@ pub fn get(map: LWWMap, key: String) -> Result(String, Nil) {
 /// replicas have observed them.
 pub fn remove(map: LWWMap, key: String, timestamp: Int) -> LWWMap {
   let should_remove = case dict.get(map.entries, key) {
-    Error(_) -> True
+    Error(Nil) -> True
     Ok(#(_, existing_ts)) -> timestamp > existing_ts
   }
   case should_remove {
@@ -217,9 +217,12 @@ pub fn merge(a: LWWMap, b: LWWMap) -> LWWMap {
     list.fold(all_keys, dict.new(), fn(acc, key) {
       let entry = case dict.get(a.entries, key), dict.get(b.entries, key) {
         Ok(ea), Ok(eb) -> Ok(choose_winner(ea, eb))
-        Ok(ea), Error(_) -> keep_if_not_zombie(ea, b.pruned_timestamp)
-        Error(_), Ok(eb) -> keep_if_not_zombie(eb, a.pruned_timestamp)
-        Error(_), Error(_) ->
+        Ok(ea), Error(Nil) -> keep_if_not_zombie(ea, b.pruned_timestamp)
+        Error(Nil), Ok(eb) -> keep_if_not_zombie(eb, a.pruned_timestamp)
+        Error(Nil), Error(Nil) ->
+          // all_keys is the union of both dicts' keys, so a key absent from
+          // both cannot occur.
+          // nolint: avoid_panic
           panic as "unreachable: key in all_keys but not in either dict"
       }
       case entry {

--- a/packages/lattice_maps/src/lattice_maps/lww_map.gleam
+++ b/packages/lattice_maps/src/lattice_maps/lww_map.gleam
@@ -69,7 +69,12 @@ pub fn pruned_timestamp(map: LWWMap) -> Int {
 ///
 /// If the key already has an entry with an equal or higher timestamp, the
 /// existing entry is kept (LWW semantics: strictly greater timestamp wins).
-pub fn set(map: LWWMap, key: String, value: String, timestamp: Int) -> LWWMap {
+pub fn set(
+  map map: LWWMap,
+  key key: String,
+  value value: String,
+  timestamp timestamp: Int,
+) -> LWWMap {
   let should_update = case dict.get(map.entries, key) {
     Error(Nil) -> True
     Ok(#(_, existing_ts)) -> timestamp > existing_ts
@@ -103,7 +108,11 @@ pub fn get(map: LWWMap, key: String) -> Result(String, Nil) {
 /// Note: This operation creates a tombstone. Use `tombstone_count` to monitor
 /// growth and `prune` with a stable timestamp to remove tombstones once all
 /// replicas have observed them.
-pub fn remove(map: LWWMap, key: String, timestamp: Int) -> LWWMap {
+pub fn remove(
+  map map: LWWMap,
+  key key: String,
+  timestamp timestamp: Int,
+) -> LWWMap {
   let should_remove = case dict.get(map.entries, key) {
     Error(Nil) -> True
     Ok(#(_, existing_ts)) -> timestamp > existing_ts

--- a/packages/lattice_maps/src/lattice_maps/or_map.gleam
+++ b/packages/lattice_maps/src/lattice_maps/or_map.gleam
@@ -191,11 +191,17 @@ pub fn merge(a: ORMap, b: ORMap) -> Result(ORMap, crdt.MergeError) {
             Ok(ca), Ok(cb) ->
               case crdt.merge(ca, cb) {
                 Ok(merged) -> merged
+                // Intentional fallback: a type mismatch between concurrently
+                // created values resolves to a fresh default of the map's spec.
+                // nolint: thrown_away_error
                 Error(_) -> crdt.default_crdt(a.crdt_spec, a.replica_id)
               }
-            Ok(ca), Error(_) -> ca
-            Error(_), Ok(cb) -> cb
-            Error(_), Error(_) ->
+            Ok(ca), Error(Nil) -> ca
+            Error(Nil), Ok(cb) -> cb
+            Error(Nil), Error(Nil) ->
+              // all_value_keys is the union of both maps' keys, so a key
+              // absent from both cannot occur.
+              // nolint: avoid_panic
               panic as "unreachable: key must exist in at least one map"
           }
           dict.insert(acc, key, merged_crdt)
@@ -218,9 +224,9 @@ pub fn merge(a: ORMap, b: ORMap) -> Result(ORMap, crdt.MergeError) {
               {
                 Ok(ba), Ok(bb) ->
                   dict.insert(acc, key, version_vector.merge(ba, bb))
-                Ok(ba), Error(_) -> dict.insert(acc, key, ba)
-                Error(_), Ok(bb) -> dict.insert(acc, key, bb)
-                Error(_), Error(_) -> acc
+                Ok(ba), Error(Nil) -> dict.insert(acc, key, ba)
+                Error(Nil), Ok(bb) -> dict.insert(acc, key, bb)
+                Error(Nil), Error(Nil) -> acc
               }
           }
         })
@@ -265,7 +271,7 @@ pub fn prune(map: ORMap, stable_vv: VersionVector) -> ORMap {
                 True -> #(vals, dict.delete(bounds, key))
                 False -> #(dict.insert(vals, key, val), bounds)
               }
-            Error(_) -> #(dict.insert(vals, key, val), bounds)
+            Error(Nil) -> #(dict.insert(vals, key, val), bounds)
           }
       }
     })
@@ -683,6 +689,9 @@ fn apply_delta_unchecked(
     dict.combine(map.values, delta.value_deltas, fn(local, incoming) {
       case crdt.merge(local, incoming) {
         Ok(merged) -> merged
+        // Intentional fallback: a type mismatch resolves to a fresh default
+        // of the map's spec.
+        // nolint: thrown_away_error
         Error(_) -> crdt.default_crdt(map.crdt_spec, map.replica_id)
       }
     })
@@ -735,6 +744,9 @@ pub fn merge_deltas(
         dict.combine(a.value_deltas, b.value_deltas, fn(va, vb) {
           case crdt.merge(va, vb) {
             Ok(m) -> m
+            // Intentional fallback: a type mismatch resolves to a fresh
+            // default delta of the map's spec.
+            // nolint: thrown_away_error
             Error(_) -> crdt.default_delta(a.crdt_spec, a.replica_id)
           }
         })

--- a/packages/lattice_maps/src/lattice_maps/or_map.gleam
+++ b/packages/lattice_maps/src/lattice_maps/or_map.gleam
@@ -20,11 +20,13 @@
 ////   })
 //// ```
 
+import gleam/bool
 import gleam/dict
 import gleam/dynamic/decode
 import gleam/int
 import gleam/json
 import gleam/list
+import gleam/result
 import gleam/set
 import lattice_core/replica_id.{type ReplicaId}
 import lattice_core/version_vector.{type VersionVector}
@@ -115,14 +117,8 @@ pub fn update(map: ORMap, key: String, f: fn(Crdt) -> Crdt) -> ORMap {
 /// Returns `Error(Nil)` if the key has never been added, or has been removed
 /// and not re-added.
 pub fn get(map: ORMap, key: String) -> Result(Crdt, Nil) {
-  case or_set.contains(map.key_set, key) {
-    True ->
-      case dict.get(map.values, key) {
-        Ok(val) -> Ok(val)
-        Error(_) -> Error(Nil)
-      }
-    False -> Error(Nil)
-  }
+  use <- bool.guard(!or_set.contains(map.key_set, key), Error(Nil))
+  dict.get(map.values, key)
 }
 
 /// Remove a key from the OR-Map.
@@ -171,75 +167,70 @@ pub fn values(map: ORMap) -> List(Crdt) {
 /// Returns `Error(TypeMismatch(...))` if the two maps have different
 /// `crdt_spec` values (e.g., one holds counters and the other holds sets).
 pub fn merge(a: ORMap, b: ORMap) -> Result(ORMap, crdt.MergeError) {
-  case a.crdt_spec == b.crdt_spec {
-    False ->
-      Error(crdt.TypeMismatch(
-        expected: spec_to_string(a.crdt_spec),
-        found: spec_to_string(b.crdt_spec),
-      ))
-    True -> {
-      let merged_key_set = or_set.merge(a.key_set, b.key_set)
-      let active_keys = or_set.value(merged_key_set)
-      let all_value_keys =
-        set.to_list(set.union(
-          set.from_list(dict.keys(a.values)),
-          set.from_list(dict.keys(b.values)),
-        ))
-      let merged_values =
-        list.fold(all_value_keys, dict.new(), fn(acc, key) {
-          let merged_crdt = case valid_value(a, key), valid_value(b, key) {
-            Ok(ca), Ok(cb) ->
-              case crdt.merge(ca, cb) {
-                Ok(merged) -> merged
-                // Intentional fallback: a type mismatch between concurrently
-                // created values resolves to a fresh default of the map's spec.
-                // nolint: thrown_away_error
-                Error(_) -> crdt.default_crdt(a.crdt_spec, a.replica_id)
-              }
-            Ok(ca), Error(Nil) -> ca
-            Error(Nil), Ok(cb) -> cb
-            Error(Nil), Error(Nil) ->
-              // all_value_keys is the union of both maps' keys, so a key
-              // absent from both cannot occur.
-              // nolint: avoid_panic
-              panic as "unreachable: key must exist in at least one map"
+  use <- bool.guard(
+    a.crdt_spec != b.crdt_spec,
+    Error(crdt.TypeMismatch(
+      expected: spec_to_string(a.crdt_spec),
+      found: spec_to_string(b.crdt_spec),
+    )),
+  )
+  let merged_key_set = or_set.merge(a.key_set, b.key_set)
+  let active_keys = or_set.value(merged_key_set)
+  let all_value_keys =
+    set.to_list(set.union(
+      set.from_list(dict.keys(a.values)),
+      set.from_list(dict.keys(b.values)),
+    ))
+  let merged_values =
+    list.fold(all_value_keys, dict.new(), fn(acc, key) {
+      let merged_crdt = case valid_value(a, key), valid_value(b, key) {
+        Ok(ca), Ok(cb) ->
+          case crdt.merge(ca, cb) {
+            Ok(merged) -> merged
+            // Intentional fallback: a type mismatch between concurrently
+            // created values resolves to a fresh default of the map's spec.
+            // nolint: thrown_away_error
+            Error(_) -> crdt.default_crdt(a.crdt_spec, a.replica_id)
           }
-          dict.insert(acc, key, merged_crdt)
-        })
+        Ok(ca), Error(Nil) -> ca
+        Error(Nil), Ok(cb) -> cb
+        Error(Nil), Error(Nil) ->
+          // all_value_keys is the union of both maps' keys, so a key
+          // absent from both cannot occur.
+          // nolint: avoid_panic
+          panic as "unreachable: key must exist in at least one map"
+      }
+      dict.insert(acc, key, merged_crdt)
+    })
 
-      // Merge remove_bounds: keep bounds for removed keys, clear for active keys
-      let all_bound_keys =
-        set.to_list(set.union(
-          set.from_list(dict.keys(a.remove_bounds)),
-          set.from_list(dict.keys(b.remove_bounds)),
-        ))
-      let merged_bounds =
-        list.fold(all_bound_keys, dict.new(), fn(acc, key) {
-          case set.contains(active_keys, key) {
-            True -> acc
-            False ->
-              case
-                dict.get(a.remove_bounds, key),
-                dict.get(b.remove_bounds, key)
-              {
-                Ok(ba), Ok(bb) ->
-                  dict.insert(acc, key, version_vector.merge(ba, bb))
-                Ok(ba), Error(Nil) -> dict.insert(acc, key, ba)
-                Error(Nil), Ok(bb) -> dict.insert(acc, key, bb)
-                Error(Nil), Error(Nil) -> acc
-              }
+  // Merge remove_bounds: keep bounds for removed keys, clear for active keys
+  let all_bound_keys =
+    set.to_list(set.union(
+      set.from_list(dict.keys(a.remove_bounds)),
+      set.from_list(dict.keys(b.remove_bounds)),
+    ))
+  let merged_bounds =
+    list.fold(all_bound_keys, dict.new(), fn(acc, key) {
+      case set.contains(active_keys, key) {
+        True -> acc
+        False ->
+          case dict.get(a.remove_bounds, key), dict.get(b.remove_bounds, key) {
+            Ok(ba), Ok(bb) ->
+              dict.insert(acc, key, version_vector.merge(ba, bb))
+            Ok(ba), Error(Nil) -> dict.insert(acc, key, ba)
+            Error(Nil), Ok(bb) -> dict.insert(acc, key, bb)
+            Error(Nil), Error(Nil) -> acc
           }
-        })
+      }
+    })
 
-      Ok(ORMap(
-        replica_id: a.replica_id,
-        crdt_spec: a.crdt_spec,
-        key_set: merged_key_set,
-        values: merged_values,
-        remove_bounds: merged_bounds,
-      ))
-    }
-  }
+  Ok(ORMap(
+    replica_id: a.replica_id,
+    crdt_spec: a.crdt_spec,
+    key_set: merged_key_set,
+    values: merged_values,
+    remove_bounds: merged_bounds,
+  ))
 }
 
 /// Prune tombstones for keys and compact removed values whose removal is
@@ -426,56 +417,43 @@ fn decode_or_map_state(
   values_list: List(#(String, String)),
   remove_bounds: dict.Dict(String, VersionVector),
 ) -> Result(ORMap, json.DecodeError) {
-  case string_to_spec(crdt_spec_str) {
-    Error(_) ->
-      Error(
-        json.UnableToDecode([
-          decode.DecodeError(
-            expected: "known CrdtSpec",
-            found: crdt_spec_str,
-            path: ["state", "crdt_spec"],
-          ),
-        ]),
+  use crdt_spec <- result.try(result.replace_error(
+    string_to_spec(crdt_spec_str),
+    json.UnableToDecode([
+      decode.DecodeError(
+        expected: "known CrdtSpec",
+        found: crdt_spec_str,
+        path: ["state", "crdt_spec"],
+      ),
+    ]),
+  ))
+  use key_set <- result.try(or_set.from_json(key_set_str))
+  use pairs <- result.try(
+    list.try_map(values_list, fn(pair) {
+      let #(key, crdt_str) = pair
+      use c <- result.try(crdt.from_json(crdt_str))
+      use <- bool.guard(
+        !matches_spec(c, crdt_spec),
+        Error(
+          json.UnableToDecode([
+            decode.DecodeError(
+              expected: spec_to_string(crdt_spec),
+              found: crdt_name(c),
+              path: ["state", "values"],
+            ),
+          ]),
+        ),
       )
-    Ok(crdt_spec) ->
-      case or_set.from_json(key_set_str) {
-        Error(e) -> Error(e)
-        Ok(key_set) -> {
-          let values_result =
-            list.try_map(values_list, fn(pair) {
-              let #(key, crdt_str) = pair
-              case crdt.from_json(crdt_str) {
-                Ok(c) ->
-                  case matches_spec(c, crdt_spec) {
-                    True -> Ok(#(key, c))
-                    False ->
-                      Error(
-                        json.UnableToDecode([
-                          decode.DecodeError(
-                            expected: spec_to_string(crdt_spec),
-                            found: crdt_name(c),
-                            path: ["state", "values"],
-                          ),
-                        ]),
-                      )
-                  }
-                Error(e) -> Error(e)
-              }
-            })
-          case values_result {
-            Error(e) -> Error(e)
-            Ok(pairs) ->
-              Ok(ORMap(
-                replica_id: replica_id.new(replica_id_str),
-                crdt_spec: crdt_spec,
-                key_set: key_set,
-                values: dict.from_list(pairs),
-                remove_bounds: remove_bounds,
-              ))
-          }
-        }
-      }
-  }
+      Ok(#(key, c))
+    }),
+  )
+  Ok(ORMap(
+    replica_id: replica_id.new(replica_id_str),
+    crdt_spec: crdt_spec,
+    key_set: key_set,
+    values: dict.from_list(pairs),
+    remove_bounds: remove_bounds,
+  ))
 }
 
 fn matches_spec(value: Crdt, spec: CrdtSpec) -> Bool {
@@ -670,14 +648,14 @@ pub fn apply_delta(
   map: ORMap,
   delta: ORMapDelta,
 ) -> Result(ORMap, crdt.MergeError) {
-  case map.crdt_spec == delta.crdt_spec {
-    False ->
-      Error(crdt.TypeMismatch(
-        expected: spec_to_string(map.crdt_spec),
-        found: spec_to_string(delta.crdt_spec),
-      ))
-    True -> apply_delta_unchecked(map, delta)
-  }
+  use <- bool.guard(
+    map.crdt_spec != delta.crdt_spec,
+    Error(crdt.TypeMismatch(
+      expected: spec_to_string(map.crdt_spec),
+      found: spec_to_string(delta.crdt_spec),
+    )),
+  )
+  apply_delta_unchecked(map, delta)
 }
 
 fn apply_delta_unchecked(
@@ -732,39 +710,37 @@ pub fn merge_deltas(
   a: ORMapDelta,
   b: ORMapDelta,
 ) -> Result(ORMapDelta, crdt.MergeError) {
-  case a.crdt_spec == b.crdt_spec {
-    False ->
-      Error(crdt.TypeMismatch(
-        expected: spec_to_string(a.crdt_spec),
-        found: spec_to_string(b.crdt_spec),
-      ))
-    True -> {
-      let merged_key_set = or_set.merge(a.key_set_delta, b.key_set_delta)
-      let merged_values =
-        dict.combine(a.value_deltas, b.value_deltas, fn(va, vb) {
-          case crdt.merge(va, vb) {
-            Ok(m) -> m
-            // Intentional fallback: a type mismatch resolves to a fresh
-            // default delta of the map's spec.
-            // nolint: thrown_away_error
-            Error(_) -> crdt.default_delta(a.crdt_spec, a.replica_id)
-          }
-        })
-      let merged_bounds =
-        dict.combine(
-          a.remove_bounds_delta,
-          b.remove_bounds_delta,
-          version_vector.merge,
-        )
-      Ok(ORMapDelta(
-        replica_id: a.replica_id,
-        crdt_spec: a.crdt_spec,
-        key_set_delta: merged_key_set,
-        value_deltas: merged_values,
-        remove_bounds_delta: merged_bounds,
-      ))
-    }
-  }
+  use <- bool.guard(
+    a.crdt_spec != b.crdt_spec,
+    Error(crdt.TypeMismatch(
+      expected: spec_to_string(a.crdt_spec),
+      found: spec_to_string(b.crdt_spec),
+    )),
+  )
+  let merged_key_set = or_set.merge(a.key_set_delta, b.key_set_delta)
+  let merged_values =
+    dict.combine(a.value_deltas, b.value_deltas, fn(va, vb) {
+      case crdt.merge(va, vb) {
+        Ok(m) -> m
+        // Intentional fallback: a type mismatch resolves to a fresh
+        // default delta of the map's spec.
+        // nolint: thrown_away_error
+        Error(_) -> crdt.default_delta(a.crdt_spec, a.replica_id)
+      }
+    })
+  let merged_bounds =
+    dict.combine(
+      a.remove_bounds_delta,
+      b.remove_bounds_delta,
+      version_vector.merge,
+    )
+  Ok(ORMapDelta(
+    replica_id: a.replica_id,
+    crdt_spec: a.crdt_spec,
+    key_set_delta: merged_key_set,
+    value_deltas: merged_values,
+    remove_bounds_delta: merged_bounds,
+  ))
 }
 
 /// Encode an `ORMapDelta` as a self-describing JSON value.
@@ -892,54 +868,41 @@ fn decode_or_map_delta_state(
   values_list: List(#(String, String)),
   bounds: dict.Dict(String, VersionVector),
 ) -> Result(ORMapDelta, json.DecodeError) {
-  case string_to_spec(crdt_spec_str) {
-    Error(_) ->
-      Error(
-        json.UnableToDecode([
-          decode.DecodeError(
-            expected: "known CrdtSpec",
-            found: crdt_spec_str,
-            path: ["state", "crdt_spec"],
-          ),
-        ]),
+  use crdt_spec <- result.try(result.replace_error(
+    string_to_spec(crdt_spec_str),
+    json.UnableToDecode([
+      decode.DecodeError(
+        expected: "known CrdtSpec",
+        found: crdt_spec_str,
+        path: ["state", "crdt_spec"],
+      ),
+    ]),
+  ))
+  use key_set_delta <- result.try(or_set.from_json(key_set_str))
+  use pairs <- result.try(
+    list.try_map(values_list, fn(pair) {
+      let #(key, crdt_str) = pair
+      use c <- result.try(crdt.from_json(crdt_str))
+      use <- bool.guard(
+        !matches_spec(c, crdt_spec),
+        Error(
+          json.UnableToDecode([
+            decode.DecodeError(
+              expected: spec_to_string(crdt_spec),
+              found: crdt_name(c),
+              path: ["state", "value_deltas"],
+            ),
+          ]),
+        ),
       )
-    Ok(crdt_spec) ->
-      case or_set.from_json(key_set_str) {
-        Error(e) -> Error(e)
-        Ok(key_set_delta) -> {
-          let values_result =
-            list.try_map(values_list, fn(pair) {
-              let #(key, crdt_str) = pair
-              case crdt.from_json(crdt_str) {
-                Ok(c) ->
-                  case matches_spec(c, crdt_spec) {
-                    True -> Ok(#(key, c))
-                    False ->
-                      Error(
-                        json.UnableToDecode([
-                          decode.DecodeError(
-                            expected: spec_to_string(crdt_spec),
-                            found: crdt_name(c),
-                            path: ["state", "value_deltas"],
-                          ),
-                        ]),
-                      )
-                  }
-                Error(e) -> Error(e)
-              }
-            })
-          case values_result {
-            Error(e) -> Error(e)
-            Ok(pairs) ->
-              Ok(ORMapDelta(
-                replica_id: replica_id.new(replica_id_str),
-                crdt_spec: crdt_spec,
-                key_set_delta: key_set_delta,
-                value_deltas: dict.from_list(pairs),
-                remove_bounds_delta: bounds,
-              ))
-          }
-        }
-      }
-  }
+      Ok(#(key, c))
+    }),
+  )
+  Ok(ORMapDelta(
+    replica_id: replica_id.new(replica_id_str),
+    crdt_spec: crdt_spec,
+    key_set_delta: key_set_delta,
+    value_deltas: dict.from_list(pairs),
+    remove_bounds_delta: bounds,
+  ))
 }

--- a/packages/lattice_presence/gleam.toml
+++ b/packages/lattice_presence/gleam.toml
@@ -16,26 +16,18 @@ glinter = ">= 2.19.0 and < 3.0.0"
 
 [tools.glinter]
 include = ["src/", "test/"]
-# warnings_as_errors makes every *enabled* rule fail CI. Rules we don't want
-# to enforce are turned off below; tests get a lenient profile in [ignore].
+# warnings_as_errors makes every *enabled* rule fail CI, so the few rules we
+# don't enforce are turned off below; tests get a lenient profile in [ignore].
 warnings_as_errors = true
 
 [tools.glinter.rules]
 # Library public API is consumed externally, so "never used in this package"
 # is expected — not an issue.
 unused_exports = "off"
-# Stylistic rules the codebase intentionally does not follow.
+# The codebase intentionally does not use argument labels.
 label_possible = "off"
-missing_labels = "off"
-short_variable_name = "off"
-missing_type_annotation = "off"
-unnecessary_variable = "off"
-prefer_guard_clause = "off"
-deep_nesting = "off"
-trailing_underscore = "off"
-unqualified_import = "off"
-
 [tools.glinter.ignore]
-# Tests use `let assert Ok(...)`, discard errors, and panic in unreachable
-# match arms by convention; these substantive rules apply to src/ only.
-"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic"]
+# Tests use `let assert Ok(...)`, discard errors, panic in unreachable match
+# arms, and skip return-type annotations by convention; these rules apply to
+# src/ only.
+"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic", "missing_type_annotation", "short_variable_name"]

--- a/packages/lattice_presence/gleam.toml
+++ b/packages/lattice_presence/gleam.toml
@@ -12,3 +12,30 @@ gleam_json = ">= 3.1.0 and < 4.0.0"
 [dev-dependencies]
 startest = ">= 0.8.0 and < 1.0.0"
 qcheck = ">= 1.0.0 and < 2.0.0"
+glinter = ">= 2.19.0 and < 3.0.0"
+
+[tools.glinter]
+include = ["src/", "test/"]
+# warnings_as_errors makes every *enabled* rule fail CI. Rules we don't want
+# to enforce are turned off below; tests get a lenient profile in [ignore].
+warnings_as_errors = true
+
+[tools.glinter.rules]
+# Library public API is consumed externally, so "never used in this package"
+# is expected — not an issue.
+unused_exports = "off"
+# Stylistic rules the codebase intentionally does not follow.
+label_possible = "off"
+missing_labels = "off"
+short_variable_name = "off"
+missing_type_annotation = "off"
+unnecessary_variable = "off"
+prefer_guard_clause = "off"
+deep_nesting = "off"
+trailing_underscore = "off"
+unqualified_import = "off"
+
+[tools.glinter.ignore]
+# Tests use `let assert Ok(...)`, discard errors, and panic in unreachable
+# match arms by convention; these substantive rules apply to src/ only.
+"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic"]

--- a/packages/lattice_presence/manifest.toml
+++ b/packages/lattice_presence/manifest.toml
@@ -6,6 +6,7 @@ packages = [
   { name = "bigben", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time", "interior"], otp_app = "bigben", source = "hex", outer_checksum = "4B0D9F2514C06AE577F284532270A6F89007781620E4B12A843388BA549C17D2" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
   { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
   { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
@@ -16,12 +17,15 @@ packages = [
   { name = "gleam_stdlib", version = "0.71.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "702F3BC2A14793906880B1078B19A6165F87323AEE8D0C4A34085846336FCAAE" },
   { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
+  { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
+  { name = "glinter", version = "2.19.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "9A0B5EE224BB84FB25DFB4A8DD3E87F06BDFE0C49B3A669D92AB4C555593FC75" },
   { name = "interior", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "interior", source = "hex", outer_checksum = "EE2728791E34400CB3CD986B6AD0E02A2F970F50B5ED59896E2820702C7DDD29" },
   { name = "prng", version = "5.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "prng", source = "hex", outer_checksum = "29DA88BCFB54D06DD1472951DF101E9524878056D139DA2616B04350B403CE10" },
   { name = "qcheck", version = "1.0.4", build_tools = ["gleam"], requirements = ["exception", "gleam_regexp", "gleam_stdlib", "gleam_yielder", "prng"], otp_app = "qcheck", source = "hex", outer_checksum = "BD9B18C1602FBC667E3E139ED270458F8C743ED791F892CC90989CE10478C4FA" },
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
   { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
@@ -29,5 +33,6 @@ packages = [
 [requirements]
 gleam_json = { version = ">= 3.1.0 and < 4.0.0" }
 gleam_stdlib = { version = ">= 0.48.0 and < 2.0.0" }
+glinter = { version = ">= 2.19.0 and < 3.0.0" }
 qcheck = { version = ">= 1.0.0 and < 2.0.0" }
 startest = { version = ">= 0.8.0 and < 1.0.0" }

--- a/packages/lattice_presence/src/lattice_presence/presence_state.gleam
+++ b/packages/lattice_presence/src/lattice_presence/presence_state.gleam
@@ -285,7 +285,7 @@ fn tag_is_in(
     _ -> {
       case dict.get(clouds, tag.replica) {
         Ok(cloud) -> set.contains(cloud, tag.clock)
-        Error(_) -> False
+        Error(Nil) -> False
       }
     }
   }
@@ -320,7 +320,7 @@ pub fn compact(state: State) -> State {
         let #(ctx, clouds) = acc
         let base = case dict.get(ctx, replica) {
           Ok(c) -> c
-          Error(_) -> 0
+          Error(Nil) -> 0
         }
         let #(new_base, remaining) = compact_cloud(base, cloud)
         let new_ctx = case new_base > base {
@@ -353,7 +353,7 @@ fn entries_to_topic_diff(
   list.fold(entries, dict.new(), fn(acc, entry) {
     let existing = case dict.get(acc, entry.topic) {
       Ok(l) -> l
-      Error(_) -> []
+      Error(Nil) -> []
     }
     dict.insert(acc, entry.topic, [
       #(entry.key, entry.pid, entry.meta),
@@ -455,7 +455,7 @@ pub fn replica_up(state: State, replica: Replica) -> #(State, Diff) {
       #(new_state, diff)
     }
     Ok(Up) -> #(state, Diff(joins: dict.new(), leaves: dict.new()))
-    Error(_) -> {
+    Error(Nil) -> {
       // First contact: record as Up but emit no diff (it was already
       // treated as up by `is_replica_up`).
       let new_replicas = dict.insert(state.replicas, replica, Up)
@@ -520,11 +520,11 @@ fn next_clock(state: State, replica: Replica) -> Clock {
   // merge — tracking the max incrementally would optimize a non-hot path.
   let ctx_clock = case dict.get(state.context, replica) {
     Ok(c) -> c
-    Error(_) -> 0
+    Error(Nil) -> 0
   }
   let cloud_max = case dict.get(state.clouds, replica) {
     Ok(cloud) -> set.fold(cloud, 0, int.max)
-    Error(_) -> 0
+    Error(Nil) -> 0
   }
   int.max(ctx_clock, cloud_max) + 1
 }
@@ -534,6 +534,6 @@ fn is_replica_up(state: State, replica: Replica) -> Bool {
     Ok(Up) -> True
     Ok(Down) -> False
     // Unknown replicas assumed up (first contact)
-    Error(_) -> True
+    Error(Nil) -> True
   }
 }

--- a/packages/lattice_presence/src/lattice_presence/presence_state.gleam
+++ b/packages/lattice_presence/src/lattice_presence/presence_state.gleam
@@ -23,6 +23,7 @@
 //// // -> [#("pid-1", "alice", _), #("pid-2", "bob", _)]
 //// ```
 
+import gleam/bool
 import gleam/dict.{type Dict}
 import gleam/int
 import gleam/json
@@ -340,10 +341,8 @@ pub fn compact(state: State) -> State {
 
 /// Compact a single cloud: advance base clock through contiguous values
 fn compact_cloud(base: Clock, cloud: Set(Clock)) -> #(Clock, Set(Clock)) {
-  case set.contains(cloud, base + 1) {
-    True -> compact_cloud(base + 1, set.delete(cloud, base + 1))
-    False -> #(base, cloud)
-  }
+  use <- bool.guard(!set.contains(cloud, base + 1), #(base, cloud))
+  compact_cloud(base + 1, set.delete(cloud, base + 1))
 }
 
 /// Group entries by topic for diff reporting

--- a/packages/lattice_presence/src/lattice_presence/presence_state.gleam
+++ b/packages/lattice_presence/src/lattice_presence/presence_state.gleam
@@ -129,11 +129,11 @@ pub fn new(replica: Replica) -> State {
 
 /// Add a tracked presence. Increments the local clock.
 pub fn join(
-  state: State,
-  pid: String,
-  topic: String,
-  key: String,
-  meta: json.Json,
+  state state: State,
+  pid pid: String,
+  topic topic: String,
+  key key: String,
+  meta meta: json.Json,
 ) -> State {
   let clock = next_clock(state, state.replica)
   let tag = Tag(replica: state.replica, clock: clock)
@@ -149,7 +149,12 @@ pub fn join(
 /// replica's entry would not be causally observed (this node's context
 /// doesn't cover the foreign tag), so it would silently reappear on the
 /// next merge. Foreign entries are filtered out at the source instead.
-pub fn leave(state: State, pid: String, topic: String, key: String) -> State {
+pub fn leave(
+  state state: State,
+  pid pid: String,
+  topic topic: String,
+  key key: String,
+) -> State {
   let new_values =
     dict.filter(state.values, fn(tag, entry) {
       tag.replica != state.replica
@@ -201,9 +206,9 @@ pub fn get_by_topic(
 
 /// Get presences for a specific key within a topic
 pub fn get_by_key(
-  state: State,
-  topic: String,
-  key: String,
+  state state: State,
+  topic topic: String,
+  key key: String,
 ) -> List(#(String, json.Json)) {
   visible_entries(state, fn(entry) { entry.topic == topic && entry.key == key })
   |> list.map(fn(entry) { #(entry.pid, entry.meta) })
@@ -496,10 +501,10 @@ pub fn replicated_parts(
 
 @internal
 pub fn from_replicated_parts(
-  replica: Replica,
-  context: Dict(Replica, Clock),
-  clouds: Dict(Replica, Set(Clock)),
-  values: Dict(Tag, Entry),
+  replica replica: Replica,
+  context context: Dict(Replica, Clock),
+  clouds clouds: Dict(Replica, Set(Clock)),
+  values values: Dict(Tag, Entry),
 ) -> State {
   State(
     replica: replica,

--- a/packages/lattice_presence/src/lattice_presence/state_json.gleam
+++ b/packages/lattice_presence/src/lattice_presence/state_json.gleam
@@ -218,6 +218,9 @@ fn json_value_list(
     [item, ..rest] ->
       case decode.run(item, json_value_decoder_at(depth)) {
         Ok(val) -> json_value_list(rest, [val, ..acc], depth)
+        // Decode boundary: per-element decode errors are replaced with a
+        // single domain-specific decoder failure.
+        // nolint: thrown_away_error
         Error(_) -> decode.failure(json.null(), "valid JSON value in array")
       }
   }
@@ -233,6 +236,9 @@ fn json_value_dict(
     [#(key, value), ..rest] ->
       case decode.run(value, json_value_decoder_at(depth)) {
         Ok(val) -> json_value_dict(rest, [#(key, val), ..acc], depth)
+        // Decode boundary: per-field decode errors are replaced with a
+        // single domain-specific decoder failure.
+        // nolint: thrown_away_error
         Error(_) -> decode.failure(json.null(), "valid JSON value in object")
       }
   }

--- a/packages/lattice_registers/gleam.toml
+++ b/packages/lattice_registers/gleam.toml
@@ -13,3 +13,30 @@ lattice_core = { path = "../lattice_core" }
 [dev-dependencies]
 startest = ">= 0.8.0 and < 1.0.0"
 qcheck = ">= 1.0.0 and < 2.0.0"
+glinter = ">= 2.19.0 and < 3.0.0"
+
+[tools.glinter]
+include = ["src/", "test/"]
+# warnings_as_errors makes every *enabled* rule fail CI. Rules we don't want
+# to enforce are turned off below; tests get a lenient profile in [ignore].
+warnings_as_errors = true
+
+[tools.glinter.rules]
+# Library public API is consumed externally, so "never used in this package"
+# is expected — not an issue.
+unused_exports = "off"
+# Stylistic rules the codebase intentionally does not follow.
+label_possible = "off"
+missing_labels = "off"
+short_variable_name = "off"
+missing_type_annotation = "off"
+unnecessary_variable = "off"
+prefer_guard_clause = "off"
+deep_nesting = "off"
+trailing_underscore = "off"
+unqualified_import = "off"
+
+[tools.glinter.ignore]
+# Tests use `let assert Ok(...)`, discard errors, and panic in unreachable
+# match arms by convention; these substantive rules apply to src/ only.
+"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic"]

--- a/packages/lattice_registers/gleam.toml
+++ b/packages/lattice_registers/gleam.toml
@@ -17,26 +17,18 @@ glinter = ">= 2.19.0 and < 3.0.0"
 
 [tools.glinter]
 include = ["src/", "test/"]
-# warnings_as_errors makes every *enabled* rule fail CI. Rules we don't want
-# to enforce are turned off below; tests get a lenient profile in [ignore].
+# warnings_as_errors makes every *enabled* rule fail CI, so the few rules we
+# don't enforce are turned off below; tests get a lenient profile in [ignore].
 warnings_as_errors = true
 
 [tools.glinter.rules]
 # Library public API is consumed externally, so "never used in this package"
 # is expected — not an issue.
 unused_exports = "off"
-# Stylistic rules the codebase intentionally does not follow.
+# The codebase intentionally does not use argument labels.
 label_possible = "off"
-missing_labels = "off"
-short_variable_name = "off"
-missing_type_annotation = "off"
-unnecessary_variable = "off"
-prefer_guard_clause = "off"
-deep_nesting = "off"
-trailing_underscore = "off"
-unqualified_import = "off"
-
 [tools.glinter.ignore]
-# Tests use `let assert Ok(...)`, discard errors, and panic in unreachable
-# match arms by convention; these substantive rules apply to src/ only.
-"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic"]
+# Tests use `let assert Ok(...)`, discard errors, panic in unreachable match
+# arms, and skip return-type annotations by convention; these rules apply to
+# src/ only.
+"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic", "missing_type_annotation", "short_variable_name"]

--- a/packages/lattice_registers/manifest.toml
+++ b/packages/lattice_registers/manifest.toml
@@ -6,6 +6,7 @@ packages = [
   { name = "bigben", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time", "interior"], otp_app = "bigben", source = "hex", outer_checksum = "4B0D9F2514C06AE577F284532270A6F89007781620E4B12A843388BA549C17D2" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
   { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
   { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
@@ -16,13 +17,16 @@ packages = [
   { name = "gleam_stdlib", version = "0.71.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "702F3BC2A14793906880B1078B19A6165F87323AEE8D0C4A34085846336FCAAE" },
   { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
+  { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
+  { name = "glinter", version = "2.19.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "9A0B5EE224BB84FB25DFB4A8DD3E87F06BDFE0C49B3A669D92AB4C555593FC75" },
   { name = "interior", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "interior", source = "hex", outer_checksum = "EE2728791E34400CB3CD986B6AD0E02A2F970F50B5ED59896E2820702C7DDD29" },
   { name = "lattice_core", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], source = "local", path = "../lattice_core" },
   { name = "prng", version = "5.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "prng", source = "hex", outer_checksum = "29DA88BCFB54D06DD1472951DF101E9524878056D139DA2616B04350B403CE10" },
   { name = "qcheck", version = "1.0.4", build_tools = ["gleam"], requirements = ["exception", "gleam_regexp", "gleam_stdlib", "gleam_yielder", "prng"], otp_app = "qcheck", source = "hex", outer_checksum = "BD9B18C1602FBC667E3E139ED270458F8C743ED791F892CC90989CE10478C4FA" },
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
   { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
@@ -30,6 +34,7 @@ packages = [
 [requirements]
 gleam_json = { version = ">= 3.1.0 and < 4.0.0" }
 gleam_stdlib = { version = ">= 0.48.0 and < 2.0.0" }
+glinter = { version = ">= 2.19.0 and < 3.0.0" }
 lattice_core = { path = "../lattice_core" }
 qcheck = { version = ">= 1.0.0 and < 2.0.0" }
 startest = { version = ">= 0.8.0 and < 1.0.0" }

--- a/packages/lattice_registers/src/lattice_registers/lww_register.gleam
+++ b/packages/lattice_registers/src/lattice_registers/lww_register.gleam
@@ -41,7 +41,11 @@ pub opaque type LWWRegister(a) {
 /// milliseconds or a Lamport clock) so that later writes have higher values.
 /// `replica_id` identifies the writing node and is used as a deterministic
 /// tie-breaker when two registers have equal timestamps during merge.
-pub fn new(val: a, timestamp: Int, replica_id: ReplicaId) -> LWWRegister(a) {
+pub fn new(
+  val val: a,
+  timestamp timestamp: Int,
+  replica_id replica_id: ReplicaId,
+) -> LWWRegister(a) {
   LWWRegister(value: val, timestamp: timestamp, replica_id: replica_id)
 }
 
@@ -54,8 +58,12 @@ pub fn new(val: a, timestamp: Int, replica_id: ReplicaId) -> LWWRegister(a) {
 ///
 /// See `set_with_delta` for the delta-state variant that also returns a
 /// small payload suitable for incremental sync (e.g. over websockets).
-pub fn set(register: LWWRegister(a), val: a, timestamp: Int) -> LWWRegister(a) {
-  let #(updated, _) = set_with_delta(register, val, timestamp)
+pub fn set(
+  register register: LWWRegister(a),
+  val val: a,
+  timestamp timestamp: Int,
+) -> LWWRegister(a) {
+  let #(updated, _) = set_with_delta(register:, val:, timestamp:)
   updated
 }
 
@@ -70,9 +78,9 @@ pub fn set(register: LWWRegister(a), val: a, timestamp: Int) -> LWWRegister(a) {
 /// Merging the delta into a remote via `merge` produces the same result as
 /// merging the new local state, preserving convergence.
 pub fn set_with_delta(
-  register: LWWRegister(a),
-  val: a,
-  timestamp: Int,
+  register register: LWWRegister(a),
+  val val: a,
+  timestamp timestamp: Int,
 ) -> #(LWWRegister(a), LWWRegister(a)) {
   use <- bool.guard(timestamp <= register.timestamp, #(register, register))
   let updated =

--- a/packages/lattice_registers/src/lattice_registers/lww_register.gleam
+++ b/packages/lattice_registers/src/lattice_registers/lww_register.gleam
@@ -17,6 +17,7 @@
 //// lww_register.value(merged)  // -> "world"
 //// ```
 
+import gleam/bool
 import gleam/dynamic/decode
 import gleam/int
 import gleam/json
@@ -73,18 +74,14 @@ pub fn set_with_delta(
   val: a,
   timestamp: Int,
 ) -> #(LWWRegister(a), LWWRegister(a)) {
-  case timestamp > register.timestamp {
-    True -> {
-      let updated =
-        LWWRegister(
-          value: val,
-          timestamp: timestamp,
-          replica_id: register.replica_id,
-        )
-      #(updated, updated)
-    }
-    False -> #(register, register)
-  }
+  use <- bool.guard(timestamp <= register.timestamp, #(register, register))
+  let updated =
+    LWWRegister(
+      value: val,
+      timestamp: timestamp,
+      replica_id: register.replica_id,
+    )
+  #(updated, updated)
 }
 
 /// Return the current value of the register.
@@ -101,20 +98,13 @@ pub fn value(register: LWWRegister(a)) -> a {
 /// `replica_id` is lexicographically greater wins, providing a fully
 /// commutative, associative, and idempotent merge.
 pub fn merge(a: LWWRegister(a), b: LWWRegister(a)) -> LWWRegister(a) {
-  case a.timestamp > b.timestamp {
-    True -> a
-    False ->
-      case a.timestamp < b.timestamp {
-        True -> b
-        False -> {
-          // Equal timestamps: use replica_id as deterministic tie-breaker
-          case replica_id.compare(a.replica_id, b.replica_id) {
-            order.Gt -> a
-            order.Lt -> b
-            order.Eq -> a
-          }
-        }
-      }
+  use <- bool.guard(a.timestamp > b.timestamp, a)
+  use <- bool.guard(a.timestamp < b.timestamp, b)
+  // Equal timestamps: use replica_id as deterministic tie-breaker
+  case replica_id.compare(a.replica_id, b.replica_id) {
+    order.Gt -> a
+    order.Lt -> b
+    order.Eq -> a
   }
 }
 

--- a/packages/lattice_sets/gleam.toml
+++ b/packages/lattice_sets/gleam.toml
@@ -13,3 +13,30 @@ lattice_core = { path = "../lattice_core" }
 [dev-dependencies]
 startest = ">= 0.8.0 and < 1.0.0"
 qcheck = ">= 1.0.0 and < 2.0.0"
+glinter = ">= 2.19.0 and < 3.0.0"
+
+[tools.glinter]
+include = ["src/", "test/"]
+# warnings_as_errors makes every *enabled* rule fail CI. Rules we don't want
+# to enforce are turned off below; tests get a lenient profile in [ignore].
+warnings_as_errors = true
+
+[tools.glinter.rules]
+# Library public API is consumed externally, so "never used in this package"
+# is expected — not an issue.
+unused_exports = "off"
+# Stylistic rules the codebase intentionally does not follow.
+label_possible = "off"
+missing_labels = "off"
+short_variable_name = "off"
+missing_type_annotation = "off"
+unnecessary_variable = "off"
+prefer_guard_clause = "off"
+deep_nesting = "off"
+trailing_underscore = "off"
+unqualified_import = "off"
+
+[tools.glinter.ignore]
+# Tests use `let assert Ok(...)`, discard errors, and panic in unreachable
+# match arms by convention; these substantive rules apply to src/ only.
+"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic"]

--- a/packages/lattice_sets/gleam.toml
+++ b/packages/lattice_sets/gleam.toml
@@ -17,26 +17,18 @@ glinter = ">= 2.19.0 and < 3.0.0"
 
 [tools.glinter]
 include = ["src/", "test/"]
-# warnings_as_errors makes every *enabled* rule fail CI. Rules we don't want
-# to enforce are turned off below; tests get a lenient profile in [ignore].
+# warnings_as_errors makes every *enabled* rule fail CI, so the few rules we
+# don't enforce are turned off below; tests get a lenient profile in [ignore].
 warnings_as_errors = true
 
 [tools.glinter.rules]
 # Library public API is consumed externally, so "never used in this package"
 # is expected — not an issue.
 unused_exports = "off"
-# Stylistic rules the codebase intentionally does not follow.
+# The codebase intentionally does not use argument labels.
 label_possible = "off"
-missing_labels = "off"
-short_variable_name = "off"
-missing_type_annotation = "off"
-unnecessary_variable = "off"
-prefer_guard_clause = "off"
-deep_nesting = "off"
-trailing_underscore = "off"
-unqualified_import = "off"
-
 [tools.glinter.ignore]
-# Tests use `let assert Ok(...)`, discard errors, and panic in unreachable
-# match arms by convention; these substantive rules apply to src/ only.
-"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic"]
+# Tests use `let assert Ok(...)`, discard errors, panic in unreachable match
+# arms, and skip return-type annotations by convention; these rules apply to
+# src/ only.
+"test/**/*.gleam" = ["assert_ok_pattern", "thrown_away_error", "discarded_result", "avoid_panic", "missing_type_annotation", "short_variable_name"]

--- a/packages/lattice_sets/manifest.toml
+++ b/packages/lattice_sets/manifest.toml
@@ -6,6 +6,7 @@ packages = [
   { name = "bigben", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time", "interior"], otp_app = "bigben", source = "hex", outer_checksum = "4B0D9F2514C06AE577F284532270A6F89007781620E4B12A843388BA549C17D2" },
   { name = "exception", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "exception", source = "hex", outer_checksum = "329D269D5C2A314F7364BD2711372B6F2C58FA6F39981572E5CA68624D291F8C" },
   { name = "filepath", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "B06A9AF0BF10E51401D64B98E4B627F1D2E48C154967DA7AF4D0914780A6D40A" },
+  { name = "glance", version = "6.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "49E0ED4793BB3F56C3E5ED00528D70CAE21D263F70A735604124B95C5F62E2DB" },
   { name = "gleam_community_ansi", version = "1.4.4", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_regexp", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "1B3AEA6074AB34D5F0674744F36DDC7290303A03295507E2DEC61EDD6F5777FE" },
   { name = "gleam_community_colour", version = "2.0.4", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "6DB4665555D7D2B27F0EA32EF47E8BEBC4303821765F9C73D483F38EE24894F0" },
   { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
@@ -16,13 +17,16 @@ packages = [
   { name = "gleam_stdlib", version = "0.71.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "702F3BC2A14793906880B1078B19A6165F87323AEE8D0C4A34085846336FCAAE" },
   { name = "gleam_time", version = "1.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_time", source = "hex", outer_checksum = "533D8723774D61AD4998324F5DD1DABDCDBFABAFB9E87CB5D03C6955448FC97D" },
   { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
+  { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
   { name = "glint", version = "1.2.1", build_tools = ["gleam"], requirements = ["gleam_community_ansi", "gleam_community_colour", "gleam_stdlib", "snag"], otp_app = "glint", source = "hex", outer_checksum = "2214C7CEFDE457CEE62140C3D4899B964E05236DA74E4243DFADF4AF29C382BB" },
+  { name = "glinter", version = "2.19.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "9A0B5EE224BB84FB25DFB4A8DD3E87F06BDFE0C49B3A669D92AB4C555593FC75" },
   { name = "interior", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_erlang", "gleam_otp", "gleam_stdlib"], otp_app = "interior", source = "hex", outer_checksum = "EE2728791E34400CB3CD986B6AD0E02A2F970F50B5ED59896E2820702C7DDD29" },
   { name = "lattice_core", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], source = "local", path = "../lattice_core" },
   { name = "prng", version = "5.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "prng", source = "hex", outer_checksum = "29DA88BCFB54D06DD1472951DF101E9524878056D139DA2616B04350B403CE10" },
   { name = "qcheck", version = "1.0.4", build_tools = ["gleam"], requirements = ["exception", "gleam_regexp", "gleam_stdlib", "gleam_yielder", "prng"], otp_app = "qcheck", source = "hex", outer_checksum = "BD9B18C1602FBC667E3E139ED270458F8C743ED791F892CC90989CE10478C4FA" },
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "snag", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "snag", source = "hex", outer_checksum = "274F41D6C3ECF99F7686FDCE54183333E41D2C1CA5A3A673F9A8B2C7A4401077" },
+  { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "startest", version = "0.8.0", build_tools = ["gleam"], requirements = ["argv", "bigben", "exception", "gleam_community_ansi", "gleam_erlang", "gleam_javascript", "gleam_regexp", "gleam_stdlib", "gleam_time", "glint", "simplifile", "tom"], otp_app = "startest", source = "hex", outer_checksum = "47362F1D9DFEFC2F81C590F73A5BFBE902F427408EFBFB48765A05512AED02DC" },
   { name = "tom", version = "2.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "DCF04CB7AB35D58CFC598C66EA2E1816D160759802C89B2BA6238780D59BC256" },
 ]
@@ -30,6 +34,7 @@ packages = [
 [requirements]
 gleam_json = { version = ">= 3.1.0 and < 4.0.0" }
 gleam_stdlib = { version = ">= 0.48.0 and < 2.0.0" }
+glinter = { version = ">= 2.19.0 and < 3.0.0" }
 lattice_core = { path = "../lattice_core" }
 qcheck = { version = ">= 1.0.0 and < 2.0.0" }
 startest = { version = ">= 0.8.0 and < 1.0.0" }

--- a/packages/lattice_sets/src/lattice_sets/or_set.gleam
+++ b/packages/lattice_sets/src/lattice_sets/or_set.gleam
@@ -197,7 +197,7 @@ pub fn remove_where(orset: ORSet(a), predicate: fn(a) -> Bool) -> ORSet(a) {
 /// survived a remove after merging).
 pub fn contains(orset: ORSet(a), element: a) -> Bool {
   case dict.get(orset.entries, element) {
-    Error(_) -> False
+    Error(Nil) -> False
     Ok(tags) -> !set.is_empty(tags)
   }
 }


### PR DESCRIPTION
Sets up [glinter](https://hex.pm/packages/glinter) linting across all packages and examples, wired into the justfile and CI as a blocking check.

## Tooling & config
- Add `glinter` (`>= 2.19.0 and < 3.0.0`) as a dev-dependency to all 7 packages + `examples`, each with a `[tools.glinter]` block in its `gleam.toml`.
- `warnings_as_errors = true` makes every *enabled* rule fail CI. Since glinter can only toggle rules on/off (not set per-rule severity), only two rules are disabled for library packages — `label_possible` (the codebase deliberately avoids argument labels) and `unused_exports` (public API is consumed externally). Tests get a lenient `[tools.glinter.ignore]` profile; examples relax a few demo-friendly rules.

## Build / CI
- `just lint` (all packages + examples) and `just lint-pkg <name>`; `lint` added to the `ci` recipe.
- New `Lint` job in `ci.yml` (the reusable workflow exposes no lint toggle).
- Normalize `examples/gleam.toml` to `[dev-dependencies]` and refresh its stale lockfile.

## Source fixes (to reach a clean, fully-enforced `src`)
- Make discarded `dict.get`/`valid_value` errors explicit: `Error(_)` → `Error(Nil)` in `lww_map`, `or_map`, `or_set`, `presence_state`.
- Replace `case True/False` early-returns with `bool.guard`, and flatten the nested JSON decoders in `or_map` with `use <- result.try` (clears `prefer_guard_clause` and `deep_nesting`).
- Add justified `// nolint:` suppressions for intentional cases: unreachable-arm `panic`s in map merges, `crdt.merge` type-mismatch fallbacks, JSON decode boundaries, and the counters' documented panic-on-invalid wrappers.