### PR TITLE
feat(text): add richer grapheme-based text operations

### DIFF
--- a/.changes/unreleased/lattice_sequence-Fixed-canonical-insert-order.yaml
+++ b/.changes/unreleased/lattice_sequence-Fixed-canonical-insert-order.yaml
@@ -1,0 +1,7 @@
+project: lattice_sequence
+kind: Fixed
+body: |-
+  Normalize item order after local inserts
+
+  A local insert positioned after tombstones could produce an item order that differed from the canonical order applied by `merge` and `from_json`, so `merge(base, delta)` was not structurally equal to the directly updated state. Inserts now run the same deterministic reordering as merge, move, and JSON decoding.
+time: 2026-07-04T21:59:52.829099406+00:00

--- a/.changes/unreleased/lattice_text-Added-richer-text-operations.yaml
+++ b/.changes/unreleased/lattice_text-Added-richer-text-operations.yaml
@@ -1,0 +1,7 @@
+project: lattice_text
+kind: Added
+body: |-
+  Add richer grapheme-based text operations
+
+  New query helpers `length`, `substring`, and `try_substring`, plus full plain/`try_*`/`*_with_delta` families for `delete_range`, `replace_range`, and `move`, and total `append`/`append_with_delta` helpers. Range operations validate `0 <= start <= end <= length` and return the new `RangeError` type on invalid input.
+time: 2026-07-04T21:59:52.829099406+00:00

--- a/docs/plans/text-crdt-richer-operations.md
+++ b/docs/plans/text-crdt-richer-operations.md
@@ -1,0 +1,82 @@
+# Plan: Richer Text CRDT Operations
+
+> Status: implemented (2026-07-04). A latent `lattice_sequence` ordering bug
+> surfaced by the `replace_range` delta tests was fixed alongside: local
+> inserts now normalize item order via `order_items`, matching merge/move/JSON
+> decoding.
+> Scope: expand `packages/lattice_text` grapheme-based operations.
+
+## Problem
+
+`packages/lattice_text/src/lattice_text/text.gleam` (~200 lines) is a thin,
+grapheme-level wrapper over `lattice_sequence`. It currently exposes only
+`new`, `insert`, `delete`, their `try_*` / `*_with_delta` variants, `values`,
+`value`, `merge`, and JSON round-trip. It lacks common text conveniences and
+does not surface several operations the underlying sequence already supports.
+
+## Goal
+
+Add **richer text operations**, all grapheme-based (consistent with existing
+`insert`/`delete`). Every new *mutating* operation gets the full family:
+plain (assert-on-error), `try_*` (returns `Result`), and `*_with_delta` /
+`try_*_with_delta` variants — matching the established module pattern.
+
+## Scope — operations to add
+
+### Query helpers (no delta)
+- `length(text) -> Int` — grapheme count (delegates to `sequence.length`).
+- `substring(text, start, end) -> String` — grapheme slice `[start, end)`,
+  clamped to bounds; add `try_substring` returning `Result` for out-of-range.
+  (Decide clamp vs. error during impl; default: `try_substring` errors,
+  `substring` clamps.)
+
+### Mutating ops (full plain / try / with_delta / try_with_delta family)
+- `delete_range(text, start, end)` — delete graphemes in `[start, end)`.
+  Implemented by repeatedly deleting at `start` (`end - start` times), since
+  each delete shifts subsequent indices left. Accumulate per-delete deltas via
+  `sequence.merge`, mirroring `insert_graphemes_with_delta`.
+- `replace_range(text, start, end, value)` — delete `[start, end)` then insert
+  `value` at `start`. Delta = merge of delete-range delta and insert delta.
+- `move(text, from_index, to_index)` — surface the existing
+  `sequence.move` / `try_move` / `*_with_delta` at grapheme granularity.
+
+### Convenience
+- `append(text, value)` — insert `value` at `length(text)` (thin helper over
+  `try_insert`; include `try_append` + delta variants only if trivial).
+
+## Notes / considerations
+- Reuse existing private helpers (`insert_graphemes_with_delta`) and add a
+  symmetric `delete_range_with_delta` private helper for delta accumulation.
+- Error types: reuse `sequence.InsertError` / `sequence.DeleteError` /
+  `sequence.MoveError`. Range ops validate `start <= end` and bounds; define
+  whether to reuse `IndexOutOfBounds` or add a text-level range error
+  (prefer reusing sequence errors to avoid new public error types).
+- Empty-range and no-op cases (`start == end`, empty string) must be handled
+  without producing spurious deltas (return identity delta like existing
+  empty-insert path at text.gleam:160).
+- Multi-grapheme correctness: keep using `string.to_graphemes` so emoji /
+  combining sequences count as one unit (covered by existing tests).
+- Multi-target: must compile & pass on Erlang and JavaScript.
+
+## Testing
+- Unit tests in `test/text/text_test.gleam`: range delete (incl. empty range,
+  full range, out-of-bounds), replace_range (shrink/grow/equal length), move,
+  substring, length, append.
+- Serialization: unchanged envelope — add a round-trip test after range/replace
+  edits in `test/serialization/text_json_test.gleam` if behavior warrants.
+- Property tests in `test/property/text_property_test.gleam`: delta correctness
+  for `delete_range`, `replace_range`, and `move` (merge(base, delta) == updated),
+  reusing the existing delta-correctness pattern.
+- Docs: add `///` doc comments with `## Examples` for each new public function.
+
+## Validation
+- `just format`
+- `just check`
+- `just test-pkg lattice_text` (Erlang) and JS target via `just test-js` (scoped
+  if possible) — confirm both targets pass.
+- `just lint-pkg lattice_text`
+
+## Out of scope (this plan)
+- Cursor/position anchoring (stable refs surviving concurrent edits).
+- Codepoint/character-indexed API variants.
+- README authoring for the package (can follow up separately).

--- a/packages/lattice_sequence/src/lattice_sequence/sequence.gleam
+++ b/packages/lattice_sequence/src/lattice_sequence/sequence.gleam
@@ -142,7 +142,7 @@ pub fn try_insert_with_delta(
         Sequence(
           replica_id: replica_id,
           counter: next_counter,
-          items: insert_item(items, origin_right, item),
+          items: insert_item(items, origin_right, item) |> order_items(),
         )
       let delta =
         Sequence(replica_id: replica_id, counter: next_counter, items: [item])

--- a/packages/lattice_sequence/test/sequence/sequence_test.gleam
+++ b/packages/lattice_sequence/test/sequence/sequence_test.gleam
@@ -151,6 +151,22 @@ pub fn merge_applies_delete_delta_test() {
   |> expect.to_equal(updated)
 }
 
+pub fn insert_after_delete_at_same_index_is_canonically_ordered_test() {
+  // Regression: a local insert whose position is preceded by tombstones must
+  // produce the same item order as merge/from_json normalization, so that
+  // merge(base, delta) structurally equals the directly updated state.
+  let base =
+    sequence.new(rid("A"))
+    |> sequence.insert(0, "a")
+    |> sequence.insert(1, "b")
+    |> sequence.delete(0)
+  let #(updated, delta) = sequence.insert_with_delta(base, 0, "x")
+
+  sequence.merge(base, delta)
+  |> expect.to_equal(updated)
+  sequence.values(updated) |> expect.to_equal(["x", "b"])
+}
+
 pub fn move_reorders_visible_item_test() {
   sequence.new(rid("A"))
   |> sequence.insert(0, "a")

--- a/packages/lattice_text/src/lattice_text/text.gleam
+++ b/packages/lattice_text/src/lattice_text/text.gleam
@@ -14,7 +14,9 @@
 //// text.value(doc)  // -> ""
 //// ```
 
+import gleam/bool
 import gleam/dynamic/decode
+import gleam/int
 import gleam/json
 import gleam/list
 import gleam/result
@@ -24,6 +26,12 @@ import lattice_sequence/sequence
 
 pub opaque type Text {
   Text(sequence: sequence.Sequence(String))
+}
+
+/// An error returned when a grapheme range does not satisfy
+/// `0 <= start <= end <= length`.
+pub type RangeError {
+  RangeOutOfBounds(start: Int, end: Int, length: Int)
 }
 
 pub fn new(replica_id: ReplicaId) -> Text {
@@ -120,6 +128,321 @@ pub fn value(text: Text) -> String {
   text
   |> values()
   |> string.concat()
+}
+
+/// Count the visible graphemes in the text.
+///
+/// ## Examples
+///
+/// ```gleam
+/// text.new(replica_id.new("A"))
+/// |> text.insert(0, "a👍")
+/// |> text.length()
+/// // -> 2
+/// ```
+pub fn length(text: Text) -> Int {
+  let Text(seq) = text
+  sequence.length(seq)
+}
+
+/// Return the graphemes in `[start, end)`, clamping both indexes to the
+/// text bounds. An empty range (including `start > end`) yields `""`.
+///
+/// ## Examples
+///
+/// ```gleam
+/// text.new(replica_id.new("A"))
+/// |> text.insert(0, "abcd")
+/// |> text.substring(1, 3)
+/// // -> "bc"
+/// ```
+pub fn substring(text: Text, start: Int, end: Int) -> String {
+  let len = length(text)
+  slice_values(text, int.clamp(start, 0, len), int.clamp(end, 0, len))
+}
+
+/// Return the graphemes in `[start, end)`, or an error when the range does
+/// not satisfy `0 <= start <= end <= length`.
+///
+/// ## Examples
+///
+/// ```gleam
+/// text.new(replica_id.new("A"))
+/// |> text.insert(0, "abc")
+/// |> text.try_substring(0, 4)
+/// // -> Error(text.RangeOutOfBounds(start: 0, end: 4, length: 3))
+/// ```
+pub fn try_substring(
+  text: Text,
+  start: Int,
+  end: Int,
+) -> Result(String, RangeError) {
+  use Nil <- result.try(validate_range(start, end, length(text)))
+  Ok(slice_values(text, start, end))
+}
+
+/// Delete the graphemes in `[start, end)`.
+///
+/// ## Examples
+///
+/// ```gleam
+/// text.new(replica_id.new("A"))
+/// |> text.insert(0, "abcd")
+/// |> text.delete_range(1, 3)
+/// |> text.value()
+/// // -> "ad"
+/// ```
+pub fn delete_range(text: Text, start: Int, end: Int) -> Text {
+  let assert Ok(updated) = try_delete_range(text, start, end)
+  updated
+}
+
+/// Safely delete the graphemes in `[start, end)`.
+pub fn try_delete_range(
+  text: Text,
+  start: Int,
+  end: Int,
+) -> Result(Text, RangeError) {
+  case try_delete_range_with_delta(text, start, end) {
+    Ok(#(updated, _delta)) -> Ok(updated)
+    Error(error) -> Error(error)
+  }
+}
+
+/// Delete a grapheme range and return both the updated text and deletion
+/// delta.
+pub fn delete_range_with_delta(
+  text: Text,
+  start: Int,
+  end: Int,
+) -> #(Text, Text) {
+  let assert Ok(result) = try_delete_range_with_delta(text, start, end)
+  result
+}
+
+/// Safely delete a grapheme range and return both the updated text and
+/// deletion delta.
+pub fn try_delete_range_with_delta(
+  text: Text,
+  start: Int,
+  end: Int,
+) -> Result(#(Text, Text), RangeError) {
+  let Text(seq) = text
+  use Nil <- result.try(validate_range(start, end, sequence.length(seq)))
+  delete_graphemes_with_delta(seq, start, end)
+  |> result.map(fn(pair) {
+    let #(updated, delta) = pair
+    #(Text(updated), Text(delta))
+  })
+}
+
+/// Replace the graphemes in `[start, end)` with a value.
+///
+/// ## Examples
+///
+/// ```gleam
+/// text.new(replica_id.new("A"))
+/// |> text.insert(0, "abcd")
+/// |> text.replace_range(1, 3, "XY")
+/// |> text.value()
+/// // -> "aXYd"
+/// ```
+pub fn replace_range(text: Text, start: Int, end: Int, value: String) -> Text {
+  let assert Ok(updated) = try_replace_range(text, start, end, value)
+  updated
+}
+
+/// Safely replace the graphemes in `[start, end)` with a value.
+pub fn try_replace_range(
+  text: Text,
+  start: Int,
+  end: Int,
+  value: String,
+) -> Result(Text, RangeError) {
+  case try_replace_range_with_delta(text, start, end, value) {
+    Ok(#(updated, _delta)) -> Ok(updated)
+    Error(error) -> Error(error)
+  }
+}
+
+/// Replace a grapheme range and return both the updated text and
+/// replacement delta.
+pub fn replace_range_with_delta(
+  text: Text,
+  start: Int,
+  end: Int,
+  value: String,
+) -> #(Text, Text) {
+  let assert Ok(result) = try_replace_range_with_delta(text, start, end, value)
+  result
+}
+
+/// Safely replace a grapheme range and return both the updated text and
+/// replacement delta.
+pub fn try_replace_range_with_delta(
+  text: Text,
+  start: Int,
+  end: Int,
+  value: String,
+) -> Result(#(Text, Text), RangeError) {
+  let Text(seq) = text
+  use Nil <- result.try(validate_range(start, end, sequence.length(seq)))
+  use #(deleted, delete_delta) <- result.try(delete_graphemes_with_delta(
+    seq,
+    start,
+    end,
+  ))
+  let graphemes = string.to_graphemes(value)
+  use #(updated, insert_delta) <- result.try(
+    insert_graphemes_with_delta(graphemes, deleted, start)
+    |> result.map_error(insert_error_to_range_error),
+  )
+  let delta = case start == end, graphemes {
+    True, [] -> updated
+    True, _ -> insert_delta
+    False, [] -> delete_delta
+    False, _ -> sequence.merge(delete_delta, insert_delta)
+  }
+  Ok(#(Text(updated), Text(delta)))
+}
+
+/// Move the grapheme at `from_index` to `to_index`.
+///
+/// The `to_index` is interpreted after removing the grapheme from
+/// `from_index`.
+///
+/// ## Examples
+///
+/// ```gleam
+/// text.new(replica_id.new("A"))
+/// |> text.insert(0, "abc")
+/// |> text.move(0, 2)
+/// |> text.value()
+/// // -> "bca"
+/// ```
+pub fn move(text: Text, from_index: Int, to_index: Int) -> Text {
+  let assert Ok(updated) = try_move(text, from_index, to_index)
+  updated
+}
+
+/// Safely move the grapheme at `from_index` to `to_index`.
+///
+/// The `to_index` is interpreted after removing the grapheme from
+/// `from_index`.
+pub fn try_move(
+  text: Text,
+  from_index: Int,
+  to_index: Int,
+) -> Result(Text, sequence.MoveError) {
+  case try_move_with_delta(text, from_index, to_index) {
+    Ok(#(updated, _delta)) -> Ok(updated)
+    Error(error) -> Error(error)
+  }
+}
+
+/// Move a grapheme and return both the updated text and move delta.
+pub fn move_with_delta(
+  text: Text,
+  from_index: Int,
+  to_index: Int,
+) -> #(Text, Text) {
+  let assert Ok(result) = try_move_with_delta(text, from_index, to_index)
+  result
+}
+
+/// Safely move a grapheme and return both the updated text and move delta.
+///
+/// The `to_index` is interpreted after removing the grapheme from
+/// `from_index`.
+pub fn try_move_with_delta(
+  text: Text,
+  from_index: Int,
+  to_index: Int,
+) -> Result(#(Text, Text), sequence.MoveError) {
+  let Text(seq) = text
+  case sequence.try_move_with_delta(seq, from_index, to_index) {
+    Ok(#(updated, delta)) -> Ok(#(Text(updated), Text(delta)))
+    Error(error) -> Error(error)
+  }
+}
+
+/// Insert a value at the end of the text. Appending is always valid, so no
+/// `try_` variant exists.
+///
+/// ## Examples
+///
+/// ```gleam
+/// text.new(replica_id.new("A"))
+/// |> text.insert(0, "ab")
+/// |> text.append("cd")
+/// |> text.value()
+/// // -> "abcd"
+/// ```
+pub fn append(text: Text, value: String) -> Text {
+  insert(text, length(text), value)
+}
+
+/// Append a value and return both the updated text and insertion delta.
+pub fn append_with_delta(text: Text, value: String) -> #(Text, Text) {
+  insert_with_delta(text, length(text), value)
+}
+
+fn validate_range(
+  start: Int,
+  end: Int,
+  length: Int,
+) -> Result(Nil, RangeError) {
+  use <- bool.guard(
+    start < 0 || end > length || start > end,
+    Error(RangeOutOfBounds(start: start, end: end, length: length)),
+  )
+  Ok(Nil)
+}
+
+fn slice_values(text: Text, start: Int, end: Int) -> String {
+  text
+  |> values()
+  |> list.drop(start)
+  |> list.take(end - start)
+  |> string.concat()
+}
+
+fn insert_error_to_range_error(error: sequence.InsertError) -> RangeError {
+  let sequence.IndexOutOfBounds(index, length) = error
+  RangeOutOfBounds(start: index, end: index, length: length)
+}
+
+fn delete_graphemes_with_delta(
+  seq: sequence.Sequence(String),
+  start: Int,
+  end: Int,
+) -> Result(#(sequence.Sequence(String), sequence.Sequence(String)), RangeError) {
+  case end - start {
+    0 -> Ok(#(seq, seq))
+    count -> {
+      use #(first_updated, first_delta) <- result.try(delete_grapheme(
+        seq,
+        start,
+      ))
+      list.repeat(Nil, count - 1)
+      |> list.try_fold(#(first_updated, first_delta), fn(state, _) {
+        let #(current, delta) = state
+        use #(updated, next_delta) <- result.try(delete_grapheme(current, start))
+        Ok(#(updated, sequence.merge(delta, next_delta)))
+      })
+    }
+  }
+}
+
+fn delete_grapheme(
+  seq: sequence.Sequence(String),
+  index: Int,
+) -> Result(#(sequence.Sequence(String), sequence.Sequence(String)), RangeError) {
+  case sequence.try_delete_with_delta(seq, index) {
+    Ok(pair) -> Ok(pair)
+    Error(sequence.DeleteIndexOutOfBounds(index, length)) ->
+      Error(RangeOutOfBounds(start: index, end: index, length: length))
+  }
 }
 
 fn insert_graphemes(

--- a/packages/lattice_text/test/property/text_property_test.gleam
+++ b/packages/lattice_text/test/property/text_property_test.gleam
@@ -105,3 +105,64 @@ pub fn text_delete_delta_correctness__test() {
     Nil
   })
 }
+
+pub fn text_delete_range_delta_correctness__test() {
+  qcheck.run(
+    small_test_config(),
+    qcheck.map2(qcheck.bounded_int(0, 4), qcheck.bounded_int(0, 4), fn(a, b) {
+      #(a, b)
+    }),
+    fn(pair) {
+      let #(a, b) = pair
+      let start = int.min(a, b)
+      let end = int.max(a, b)
+      let base = text.new(rid("A")) |> text.insert(0, "abcd")
+      let #(direct, delta) = text.delete_range_with_delta(base, start, end)
+
+      text.merge(base, delta) |> expect.to_equal(direct)
+      Nil
+    },
+  )
+}
+
+pub fn text_replace_range_delta_correctness__test() {
+  qcheck.run(
+    small_test_config(),
+    qcheck.map3(
+      qcheck.bounded_int(0, 4),
+      qcheck.bounded_int(0, 4),
+      qcheck.bounded_int(0, 100),
+      fn(a, b, n) { #(a, b, n) },
+    ),
+    fn(triple) {
+      let #(a, b, n) = triple
+      let start = int.min(a, b)
+      let end = int.max(a, b)
+      let base = text.new(rid("A")) |> text.insert(0, "abcd")
+      let #(direct, delta) =
+        text.replace_range_with_delta(base, start, end, int.to_string(n))
+
+      text.merge(base, delta) |> expect.to_equal(direct)
+      Nil
+    },
+  )
+}
+
+pub fn text_move_delta_correctness__test() {
+  qcheck.run(
+    small_test_config(),
+    qcheck.map2(
+      qcheck.bounded_int(0, 3),
+      qcheck.bounded_int(0, 3),
+      fn(from_index, to_index) { #(from_index, to_index) },
+    ),
+    fn(pair) {
+      let #(from_index, to_index) = pair
+      let base = text.new(rid("A")) |> text.insert(0, "abcd")
+      let #(direct, delta) = text.move_with_delta(base, from_index, to_index)
+
+      text.merge(base, delta) |> expect.to_equal(direct)
+      Nil
+    },
+  )
+}

--- a/packages/lattice_text/test/serialization/text_json_test.gleam
+++ b/packages/lattice_text/test/serialization/text_json_test.gleam
@@ -31,6 +31,17 @@ pub fn text_round_trip_with_tombstone_test() {
   |> expect.to_equal(Ok(doc))
 }
 
+pub fn text_round_trip_after_replace_range_test() {
+  let doc =
+    text.new(rid("A"))
+    |> text.insert(0, "abcd")
+    |> text.replace_range(1, 3, "XY")
+
+  json.to_string(text.to_json(doc))
+  |> text.from_json()
+  |> expect.to_equal(Ok(doc))
+}
+
 pub fn text_to_json_uses_sequence_envelope_test() {
   let doc = text.new(rid("A")) |> text.insert(0, "x")
 

--- a/packages/lattice_text/test/text/text_test.gleam
+++ b/packages/lattice_text/test/text/text_test.gleam
@@ -175,3 +175,261 @@ pub fn merge_applies_delete_delta_test() {
   text.merge(base, delta)
   |> expect.to_equal(updated)
 }
+
+pub fn length_of_empty_text_is_zero_test() {
+  text.new(rid("A"))
+  |> text.length()
+  |> expect.to_equal(0)
+}
+
+pub fn length_counts_graphemes_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "a👍b")
+  |> text.length()
+  |> expect.to_equal(3)
+}
+
+pub fn substring_returns_slice_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abcd")
+  |> text.substring(1, 3)
+  |> expect.to_equal("bc")
+}
+
+pub fn substring_clamps_out_of_bounds_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abc")
+  |> text.substring(-2, 10)
+  |> expect.to_equal("abc")
+}
+
+pub fn substring_start_greater_than_end_returns_empty_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abc")
+  |> text.substring(2, 1)
+  |> expect.to_equal("")
+}
+
+pub fn substring_slices_graphemes_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "a👍b")
+  |> text.substring(1, 2)
+  |> expect.to_equal("👍")
+}
+
+pub fn try_substring_valid_range_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abcd")
+  |> text.try_substring(1, 3)
+  |> expect.to_equal(Ok("bc"))
+}
+
+pub fn try_substring_negative_start_returns_error_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abc")
+  |> text.try_substring(-1, 2)
+  |> expect.to_equal(Error(text.RangeOutOfBounds(start: -1, end: 2, length: 3)))
+}
+
+pub fn try_substring_end_past_length_returns_error_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abc")
+  |> text.try_substring(0, 4)
+  |> expect.to_equal(Error(text.RangeOutOfBounds(start: 0, end: 4, length: 3)))
+}
+
+pub fn try_substring_start_greater_than_end_returns_error_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abc")
+  |> text.try_substring(2, 1)
+  |> expect.to_equal(Error(text.RangeOutOfBounds(start: 2, end: 1, length: 3)))
+}
+
+pub fn delete_range_removes_middle_graphemes_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abcd")
+  |> text.delete_range(1, 3)
+  |> text.value()
+  |> expect.to_equal("ad")
+}
+
+pub fn delete_range_empty_range_is_noop_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abc")
+  |> text.delete_range(1, 1)
+  |> text.value()
+  |> expect.to_equal("abc")
+}
+
+pub fn delete_range_full_range_empties_text_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abc")
+  |> text.delete_range(0, 3)
+  |> text.value()
+  |> expect.to_equal("")
+}
+
+pub fn delete_range_handles_multi_grapheme_content_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "a👍b")
+  |> text.delete_range(1, 2)
+  |> text.value()
+  |> expect.to_equal("ab")
+}
+
+pub fn try_delete_range_negative_start_returns_error_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abc")
+  |> text.try_delete_range(-1, 2)
+  |> expect.to_equal(Error(text.RangeOutOfBounds(start: -1, end: 2, length: 3)))
+}
+
+pub fn try_delete_range_end_past_length_returns_error_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abc")
+  |> text.try_delete_range(0, 4)
+  |> expect.to_equal(Error(text.RangeOutOfBounds(start: 0, end: 4, length: 3)))
+}
+
+pub fn try_delete_range_start_greater_than_end_returns_error_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abc")
+  |> text.try_delete_range(2, 1)
+  |> expect.to_equal(Error(text.RangeOutOfBounds(start: 2, end: 1, length: 3)))
+}
+
+pub fn merge_applies_delete_range_delta_test() {
+  let base = text.new(rid("A")) |> text.insert(0, "abcd")
+  let #(updated, delta) = text.delete_range_with_delta(base, 1, 3)
+
+  text.merge(base, delta)
+  |> expect.to_equal(updated)
+}
+
+pub fn replace_range_with_equal_length_value_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abcd")
+  |> text.replace_range(1, 3, "XY")
+  |> text.value()
+  |> expect.to_equal("aXYd")
+}
+
+pub fn replace_range_with_shorter_value_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abcd")
+  |> text.replace_range(1, 3, "X")
+  |> text.value()
+  |> expect.to_equal("aXd")
+}
+
+pub fn replace_range_with_longer_value_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abcd")
+  |> text.replace_range(1, 3, "XYZ")
+  |> text.value()
+  |> expect.to_equal("aXYZd")
+}
+
+pub fn replace_range_empty_range_inserts_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abc")
+  |> text.replace_range(1, 1, "X")
+  |> text.value()
+  |> expect.to_equal("aXbc")
+}
+
+pub fn replace_range_empty_value_deletes_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abcd")
+  |> text.replace_range(1, 3, "")
+  |> text.value()
+  |> expect.to_equal("ad")
+}
+
+pub fn try_replace_range_invalid_range_returns_error_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abc")
+  |> text.try_replace_range(2, 1, "x")
+  |> expect.to_equal(Error(text.RangeOutOfBounds(start: 2, end: 1, length: 3)))
+}
+
+pub fn merge_applies_replace_range_delta_test() {
+  let base = text.new(rid("A")) |> text.insert(0, "abcd")
+  let #(updated, delta) = text.replace_range_with_delta(base, 1, 3, "XY")
+
+  text.merge(base, delta)
+  |> expect.to_equal(updated)
+}
+
+pub fn move_forward_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abc")
+  |> text.move(0, 2)
+  |> text.value()
+  |> expect.to_equal("bca")
+}
+
+pub fn move_backward_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abc")
+  |> text.move(2, 0)
+  |> text.value()
+  |> expect.to_equal("cab")
+}
+
+pub fn try_move_from_index_out_of_bounds_returns_error_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abc")
+  |> text.try_move(3, 0)
+  |> expect.to_equal(
+    Error(sequence.MoveFromIndexOutOfBounds(index: 3, length: 3)),
+  )
+}
+
+pub fn try_move_to_index_out_of_bounds_returns_error_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "abc")
+  |> text.try_move(0, 3)
+  |> expect.to_equal(
+    Error(sequence.MoveToIndexOutOfBounds(index: 3, length_after_removal: 2)),
+  )
+}
+
+pub fn merge_applies_move_delta_test() {
+  let base = text.new(rid("A")) |> text.insert(0, "abc")
+  let #(updated, delta) = text.move_with_delta(base, 0, 2)
+
+  text.merge(base, delta)
+  |> expect.to_equal(updated)
+}
+
+pub fn append_to_empty_text_test() {
+  text.new(rid("A"))
+  |> text.append("hi")
+  |> text.value()
+  |> expect.to_equal("hi")
+}
+
+pub fn append_to_existing_text_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "ab")
+  |> text.append("cd")
+  |> text.value()
+  |> expect.to_equal("abcd")
+}
+
+pub fn append_multi_grapheme_value_test() {
+  text.new(rid("A"))
+  |> text.insert(0, "a")
+  |> text.append("👍!")
+  |> text.value()
+  |> expect.to_equal("a👍!")
+}
+
+pub fn merge_applies_append_delta_test() {
+  let base = text.new(rid("A")) |> text.insert(0, "ab")
+  let #(updated, delta) = text.append_with_delta(base, "cd")
+
+  text.merge(base, delta)
+  |> expect.to_equal(updated)
+}


### PR DESCRIPTION
## Summary

Implements the richer text operations plan (`docs/plans/text-crdt-richer-operations.md`) for `lattice_text`, and fixes a latent ordering bug in `lattice_sequence` that the new tests surfaced.

### lattice_text (minor)

All grapheme-based, following the established plain / `try_*` / `*_with_delta` / `try_*_with_delta` family pattern:

- **Query helpers**: `length`, `substring` (clamps out-of-range indexes), `try_substring` (errors instead)
- **`delete_range(start, end)`**: full op family; deletes `[start, end)` accumulating per-grapheme deltas via `sequence.merge`
- **`replace_range(start, end, value)`**: full op family; delta is the merge of the delete and insert deltas, degrading to pure insert/delete when the range or value is empty
- **`move(from, to)`**: full op family surfacing `sequence.move` at grapheme granularity (reuses `sequence.MoveError`)
- **`append` / `append_with_delta`**: insert at end; total, so no `try_` variants
- **New `RangeError` type** (`RangeOutOfBounds(start, end, length)`) returned by the range ops when `0 <= start <= end <= length` doesn't hold. Deviates from the design doc's "reuse sequence errors" preference because no sequence error can honestly express `start > end`, and `try_substring` returning a `DeleteError` would misdescribe a read-only op.

### lattice_sequence (patch, own commit)

The new `replace_range` delta-correctness tests exposed that a local insert positioned after tombstones produced an item order differing from the canonical order that `merge`, `from_json`, and `move` all apply via `order_items()` — so `merge(base, delta)` was not structurally equal to the directly updated state. Local inserts now normalize through `order_items()` like every other reordering path; regression test included.
