### PR TITLE
feat(text): add stable cursor anchors to sequence and text

### DIFF
--- a/.changes/unreleased/lattice_sequence-Added-anchors.yaml
+++ b/.changes/unreleased/lattice_sequence-Added-anchors.yaml
@@ -1,0 +1,7 @@
+project: lattice_sequence
+kind: Added
+body: |-
+  Add stable position anchors with `anchor_at`, `resolve`, and JSON serialization
+
+  Anchors name a gap between items and survive concurrent edits and merges: `anchor_at`/`try_anchor_at` create one from a visible index with a `Bias` (`Before` or `After`) controlling which side of the gap it sticks to, and `resolve`/`try_resolve` map it back to a current index. `start_anchor` and `end_anchor` provide sentinels, and `anchor_to_json`/`anchor_from_json` let anchors travel between replicas for shared-cursor features. Anchors on deleted items collapse to the gap left behind, and anchors follow moved items.
+time: 2026-07-04T22:36:54.630494870+00:00

--- a/.changes/unreleased/lattice_text-Added-anchors.yaml
+++ b/.changes/unreleased/lattice_text-Added-anchors.yaml
@@ -1,0 +1,7 @@
+project: lattice_text
+kind: Added
+body: |-
+  Add grapheme-level cursor anchors with `anchor_at`, `resolve_anchor`, and JSON serialization
+
+  Anchors are stable positions that survive concurrent edits and merges, so editors can keep cursors and selections in place across remote inserts and deletes. `anchor_at`/`try_anchor_at` create an anchor at a grapheme index with a `Before` or `After` bias, `resolve_anchor`/`try_resolve_anchor` map it back to a current index, and `start_anchor`/`end_anchor`/`anchor_to_json`/`anchor_from_json` round out the surface without callers needing to import `lattice_sequence`.
+time: 2026-07-04T22:36:54.630494870+00:00

--- a/packages/lattice_sequence/src/lattice_sequence/sequence.gleam
+++ b/packages/lattice_sequence/src/lattice_sequence/sequence.gleam
@@ -76,6 +76,35 @@ pub type MoveError {
   MoveToIndexOutOfBounds(index: Int, length_after_removal: Int)
 }
 
+/// Which side of its gap an anchor sticks to when content is inserted
+/// exactly at the anchor position.
+pub type Bias {
+  /// Attach to the item after the gap: inserts at the gap push the anchor
+  /// right, so it stays glued to its item.
+  Before
+  /// Attach to the item before the gap: inserts at the gap land after the
+  /// anchor, so it stays put.
+  After
+}
+
+/// A stable position between items (positions `0..length` inclusive).
+///
+/// Anchors are created from a visible index with `anchor_at` and resolved
+/// back to a current index with `resolve` after any sequence of local edits
+/// and merges. They live outside the CRDT state: creating and resolving
+/// anchors never mutates the sequence.
+pub opaque type Anchor {
+  Start
+  End
+  AtItem(id: ItemId, bias: Bias)
+}
+
+/// An error returned when an anchor cannot be created or resolved.
+pub type AnchorError {
+  AnchorIndexOutOfBounds(index: Int, length: Int)
+  UnknownAnchorTarget
+}
+
 /// Create an empty sequence for a replica.
 pub fn new(replica_id: ReplicaId) -> Sequence(a) {
   Sequence(replica_id: replica_id, counter: 0, items: [])
@@ -323,6 +352,193 @@ fn move_visible_item(
   }
 }
 
+/// Create an anchor at the start of the sequence. Always resolves to 0.
+pub fn start_anchor() -> Anchor {
+  Start
+}
+
+/// Create an anchor at the end of the sequence. Always resolves to the
+/// current visible length, tracking growth.
+pub fn end_anchor() -> Anchor {
+  End
+}
+
+/// Create an anchor at the gap before the visible item at `index`.
+///
+/// `Before` bias binds the anchor to the item at `index`; `After` bias binds
+/// it to the item at `index - 1`. Boundary positions with no item on the
+/// chosen side degrade to the start / end sentinels.
+pub fn anchor_at(sequence: Sequence(a), index: Int, bias: Bias) -> Anchor {
+  let assert Ok(anchor) = try_anchor_at(sequence, index, bias)
+  anchor
+}
+
+/// Safely create an anchor at the gap before the visible item at `index`.
+///
+/// Valid positions are `0 <= index <= length`.
+pub fn try_anchor_at(
+  sequence: Sequence(a),
+  index: Int,
+  bias: Bias,
+) -> Result(Anchor, AnchorError) {
+  let Sequence(_, _, items) = sequence
+  let size = visible_length(items)
+
+  case index < 0 || index > size {
+    True -> Error(AnchorIndexOutOfBounds(index: index, length: size))
+    False ->
+      case bias {
+        Before ->
+          case visible_item_id_at(items, index) {
+            Some(id) -> Ok(AtItem(id: id, bias: Before))
+            None -> Ok(End)
+          }
+        After ->
+          case visible_item_id_at(items, index - 1) {
+            Some(id) -> Ok(AtItem(id: id, bias: After))
+            None -> Ok(Start)
+          }
+      }
+  }
+}
+
+/// Resolve an anchor to a current visible index in `[0, length]`.
+///
+/// Anchors on deleted items still resolve: both biases collapse to the gap
+/// where the item used to be. Anchors follow moved items.
+pub fn resolve(sequence: Sequence(a), anchor: Anchor) -> Int {
+  let assert Ok(index) = try_resolve(sequence, anchor)
+  index
+}
+
+/// Safely resolve an anchor to a current visible index in `[0, length]`.
+///
+/// Returns `Error(UnknownAnchorTarget)` when the anchor references an item
+/// this replica has never seen (created remotely and not yet merged).
+pub fn try_resolve(
+  sequence: Sequence(a),
+  anchor: Anchor,
+) -> Result(Int, AnchorError) {
+  let Sequence(_, _, items) = sequence
+
+  case anchor {
+    Start -> Ok(0)
+    End -> Ok(visible_length(items))
+    AtItem(id, bias) -> resolve_item_anchor(items, id, bias, 0)
+  }
+}
+
+fn resolve_item_anchor(
+  items: List(Item(a)),
+  id: ItemId,
+  bias: Bias,
+  visible_before: Int,
+) -> Result(Int, AnchorError) {
+  case items {
+    [] -> Error(UnknownAnchorTarget)
+    [item, ..rest] ->
+      case item.id == id {
+        True ->
+          case bias, item.deleted {
+            After, False -> Ok(visible_before + 1)
+            _, _ -> Ok(visible_before)
+          }
+        False ->
+          case item.deleted {
+            True -> resolve_item_anchor(rest, id, bias, visible_before)
+            False -> resolve_item_anchor(rest, id, bias, visible_before + 1)
+          }
+      }
+  }
+}
+
+/// Encode an anchor as a self-describing JSON value.
+///
+/// Produces an envelope with `type`, `v` (schema version), and `anchor`, so
+/// anchors can travel between replicas (e.g. shared cursors).
+pub fn anchor_to_json(anchor: Anchor) -> json.Json {
+  let encoded = case anchor {
+    Start -> json.object([#("kind", json.string("start"))])
+    End -> json.object([#("kind", json.string("end"))])
+    AtItem(id, bias) ->
+      json.object([
+        #("kind", json.string("item")),
+        #("id", encode_item_id(id)),
+        #("bias", encode_bias(bias)),
+      ])
+  }
+
+  json.object([
+    #("type", json.string("anchor")),
+    #("v", json.int(1)),
+    #("anchor", encoded),
+  ])
+}
+
+/// Decode an anchor from a JSON string produced by `anchor_to_json`.
+pub fn anchor_from_json(
+  json_string: String,
+) -> Result(Anchor, json.DecodeError) {
+  let anchor_decoder = {
+    use kind <- decode.field("kind", decode.string)
+    case kind {
+      "start" -> decode.success(Start)
+      "end" -> decode.success(End)
+      "item" -> {
+        use id <- decode.field("id", item_id_decoder())
+        use bias <- decode.field("bias", bias_decoder())
+        decode.success(AtItem(id: id, bias: bias))
+      }
+      _ -> decode.failure(Start, "one of start, end, item")
+    }
+  }
+  let envelope_decoder = {
+    use type_tag <- decode.field("type", decode.string)
+    use version <- decode.field("v", decode.int)
+    decode.success(#(type_tag, version))
+  }
+
+  case json.parse(from: json_string, using: envelope_decoder) {
+    Error(e) -> Error(e)
+    Ok(#(type_tag, version)) ->
+      case type_tag == "anchor" && version == 1 {
+        True ->
+          json.parse(from: json_string, using: {
+            use anchor <- decode.field("anchor", anchor_decoder)
+            decode.success(anchor)
+          })
+        False ->
+          Error(
+            json.UnableToDecode([
+              decode.DecodeError(
+                expected: "type=anchor and v=1",
+                found: type_tag <> " v=" <> int.to_string(version),
+                path: [],
+              ),
+            ]),
+          )
+      }
+  }
+}
+
+fn encode_bias(bias: Bias) -> json.Json {
+  case bias {
+    Before -> json.string("before")
+    After -> json.string("after")
+  }
+}
+
+fn bias_decoder() -> decode.Decoder(Bias) {
+  decode.string
+  |> decode.then(fn(value) {
+    case value {
+      "before" -> decode.success(Before)
+      "after" -> decode.success(After)
+      _ -> decode.failure(Before, "before or after")
+    }
+  })
+}
+
 /// Return all visible values in sequence order.
 pub fn values(sequence: Sequence(a)) -> List(a) {
   let Sequence(_, _, items) = sequence
@@ -387,35 +603,22 @@ pub fn from_json(
   json_string: String,
   value_decoder: decode.Decoder(a),
 ) -> Result(Sequence(a), json.DecodeError) {
-  let non_negative_int =
-    decode.int
-    |> decode.then(fn(val) {
-      case val >= 0 {
-        True -> decode.success(val)
-        False -> decode.failure(val, "a non-negative integer")
-      }
-    })
-  let item_id_decoder = {
-    use rid <- decode.field("replica_id", replica_id.decoder())
-    use counter <- decode.field("counter", non_negative_int)
-    decode.success(ItemId(replica_id: rid, counter: counter))
-  }
   let item_decoder = {
-    use id <- decode.field("id", item_id_decoder)
+    use id <- decode.field("id", item_id_decoder())
     use origin_left <- decode.field(
       "origin_left",
-      decode.optional(item_id_decoder),
+      decode.optional(item_id_decoder()),
     )
     use origin_right <- decode.field(
       "origin_right",
-      decode.optional(item_id_decoder),
+      decode.optional(item_id_decoder()),
     )
     use value <- decode.field("value", value_decoder)
     use deleted <- decode.field("deleted", decode.bool)
     use move <- decode.optional_field(
       "move",
       None,
-      decode.optional(move_decoder(item_id_decoder, non_negative_int)),
+      decode.optional(move_decoder()),
     )
     decode.success(Item(
       id: id,
@@ -429,7 +632,7 @@ pub fn from_json(
   let state_decoder = {
     use state <- decode.field("state", {
       use self_id <- decode.field("self_id", replica_id.decoder())
-      use counter <- decode.field("counter", non_negative_int)
+      use counter <- decode.field("counter", non_negative_int_decoder())
       use items <- decode.field("items", decode.list(item_decoder))
       decode.success(Sequence(
         replica_id: self_id,
@@ -464,13 +667,10 @@ pub fn from_json(
   }
 }
 
-fn move_decoder(
-  item_id_decoder: decode.Decoder(ItemId),
-  non_negative_int: decode.Decoder(Int),
-) -> decode.Decoder(Move) {
+fn move_decoder() -> decode.Decoder(Move) {
   let op_id_decoder = {
     use rid <- decode.field("replica_id", replica_id.decoder())
-    use counter <- decode.field("counter", non_negative_int)
+    use counter <- decode.field("counter", non_negative_int_decoder())
     decode.success(OpId(replica_id: rid, counter: counter))
   }
 
@@ -478,11 +678,11 @@ fn move_decoder(
     use op_id <- decode.field("op_id", op_id_decoder)
     use origin_left <- decode.field(
       "origin_left",
-      decode.optional(item_id_decoder),
+      decode.optional(item_id_decoder()),
     )
     use origin_right <- decode.field(
       "origin_right",
-      decode.optional(item_id_decoder),
+      decode.optional(item_id_decoder()),
     )
     decode.success(Move(
       op_id: op_id,
@@ -490,6 +690,22 @@ fn move_decoder(
       origin_right: origin_right,
     ))
   }
+}
+
+fn non_negative_int_decoder() -> decode.Decoder(Int) {
+  decode.int
+  |> decode.then(fn(val) {
+    case val >= 0 {
+      True -> decode.success(val)
+      False -> decode.failure(val, "a non-negative integer")
+    }
+  })
+}
+
+fn item_id_decoder() -> decode.Decoder(ItemId) {
+  use rid <- decode.field("replica_id", replica_id.decoder())
+  use counter <- decode.field("counter", non_negative_int_decoder())
+  decode.success(ItemId(replica_id: rid, counter: counter))
 }
 
 fn encode_item(item: Item(a), encode_value: fn(a) -> json.Json) -> json.Json {

--- a/packages/lattice_sequence/test/sequence/anchor_test.gleam
+++ b/packages/lattice_sequence/test/sequence/anchor_test.gleam
@@ -1,0 +1,197 @@
+import lattice_core/replica_id
+import lattice_sequence/sequence.{After, Before}
+import startest/expect
+
+fn rid(id: String) {
+  replica_id.new(id)
+}
+
+fn abc() {
+  sequence.new(rid("A"))
+  |> sequence.insert(0, "a")
+  |> sequence.insert(1, "b")
+  |> sequence.insert(2, "c")
+}
+
+pub fn start_anchor_resolves_to_zero_test() {
+  let seq = abc()
+  sequence.resolve(seq, sequence.start_anchor())
+  |> expect.to_equal(0)
+}
+
+pub fn start_anchor_stays_at_zero_after_insert_at_front_test() {
+  let seq = abc() |> sequence.insert(0, "x")
+  sequence.resolve(seq, sequence.start_anchor())
+  |> expect.to_equal(0)
+}
+
+pub fn end_anchor_tracks_growth_test() {
+  let anchor = sequence.end_anchor()
+  let seq = abc()
+
+  sequence.resolve(seq, anchor) |> expect.to_equal(3)
+  sequence.resolve(sequence.insert(seq, 3, "d"), anchor) |> expect.to_equal(4)
+  sequence.resolve(sequence.new(rid("A")), anchor) |> expect.to_equal(0)
+}
+
+pub fn try_anchor_at_negative_index_returns_error_test() {
+  abc()
+  |> sequence.try_anchor_at(-1, Before)
+  |> expect.to_equal(
+    Error(sequence.AnchorIndexOutOfBounds(index: -1, length: 3)),
+  )
+}
+
+pub fn try_anchor_at_past_length_returns_error_test() {
+  abc()
+  |> sequence.try_anchor_at(4, After)
+  |> expect.to_equal(
+    Error(sequence.AnchorIndexOutOfBounds(index: 4, length: 3)),
+  )
+}
+
+pub fn try_anchor_at_length_is_valid_test() {
+  let seq = abc()
+  let assert Ok(anchor) = sequence.try_anchor_at(seq, 3, Before)
+  sequence.resolve(seq, anchor) |> expect.to_equal(3)
+}
+
+pub fn anchor_at_length_with_before_bias_degrades_to_end_test() {
+  let seq = abc()
+  let anchor = sequence.anchor_at(seq, 3, Before)
+
+  // A true End sentinel tracks growth at the tail.
+  sequence.resolve(sequence.insert(seq, 3, "d"), anchor)
+  |> expect.to_equal(4)
+}
+
+pub fn anchor_at_zero_with_after_bias_degrades_to_start_test() {
+  let seq = abc()
+  let anchor = sequence.anchor_at(seq, 0, After)
+
+  // A true Start sentinel stays at 0 even when content is inserted at 0.
+  sequence.resolve(sequence.insert(seq, 0, "x"), anchor)
+  |> expect.to_equal(0)
+}
+
+pub fn anchor_on_empty_sequence_resolves_to_zero_test() {
+  let seq = sequence.new(rid("A"))
+
+  sequence.resolve(seq, sequence.anchor_at(seq, 0, Before))
+  |> expect.to_equal(0)
+  sequence.resolve(seq, sequence.anchor_at(seq, 0, After))
+  |> expect.to_equal(0)
+}
+
+pub fn create_then_resolve_is_identity_test() {
+  let seq = abc()
+
+  sequence.resolve(seq, sequence.anchor_at(seq, 0, Before))
+  |> expect.to_equal(0)
+  sequence.resolve(seq, sequence.anchor_at(seq, 1, Before))
+  |> expect.to_equal(1)
+  sequence.resolve(seq, sequence.anchor_at(seq, 1, After))
+  |> expect.to_equal(1)
+  sequence.resolve(seq, sequence.anchor_at(seq, 2, After))
+  |> expect.to_equal(2)
+  sequence.resolve(seq, sequence.anchor_at(seq, 3, After))
+  |> expect.to_equal(3)
+}
+
+pub fn insert_before_anchor_shifts_it_right_test() {
+  let seq = abc()
+  let anchor = sequence.anchor_at(seq, 2, Before)
+
+  sequence.resolve(sequence.insert(seq, 0, "x"), anchor)
+  |> expect.to_equal(3)
+}
+
+pub fn delete_before_anchor_shifts_it_left_test() {
+  let seq = abc()
+  let anchor = sequence.anchor_at(seq, 2, Before)
+
+  sequence.resolve(sequence.delete(seq, 0), anchor)
+  |> expect.to_equal(1)
+}
+
+pub fn insert_after_anchor_does_not_move_it_test() {
+  let seq = abc()
+  let anchor = sequence.anchor_at(seq, 1, After)
+
+  sequence.resolve(sequence.insert(seq, 2, "x"), anchor)
+  |> expect.to_equal(1)
+}
+
+pub fn bias_diverges_for_insert_exactly_at_the_gap_test() {
+  let seq = abc()
+  let before = sequence.anchor_at(seq, 1, Before)
+  let after = sequence.anchor_at(seq, 1, After)
+  let updated = sequence.insert(seq, 1, "x")
+
+  // Before stays glued to "b", which was pushed right.
+  sequence.resolve(updated, before) |> expect.to_equal(2)
+  // After stays glued to "a", so the insert lands after the anchor.
+  sequence.resolve(updated, after) |> expect.to_equal(1)
+}
+
+pub fn anchor_survives_deletion_of_its_item_test() {
+  let seq = abc()
+  let before = sequence.anchor_at(seq, 1, Before)
+  let after = sequence.anchor_at(seq, 2, After)
+  // Both anchors bind to "b"; delete it.
+  let updated = sequence.delete(seq, 1)
+
+  // Both biases collapse to the gap where "b" used to be.
+  sequence.resolve(updated, before) |> expect.to_equal(1)
+  sequence.resolve(updated, after) |> expect.to_equal(1)
+}
+
+pub fn anchor_follows_moved_item_test() {
+  let seq = abc()
+  let anchor = sequence.anchor_at(seq, 0, Before)
+  // Move "a" to the end: "bca".
+  let updated = sequence.move(seq, 0, 2)
+
+  sequence.resolve(updated, anchor) |> expect.to_equal(2)
+}
+
+pub fn try_resolve_unknown_target_before_merge_errors_test() {
+  let alice = abc()
+  let bob =
+    sequence.merge(sequence.new(rid("B")), alice)
+    |> sequence.insert(1, "x")
+  let anchor = sequence.anchor_at(bob, 1, Before)
+
+  // Alice has never seen Bob's item.
+  sequence.try_resolve(alice, anchor)
+  |> expect.to_equal(Error(sequence.UnknownAnchorTarget))
+
+  // After merging Bob's state, the anchor resolves.
+  sequence.try_resolve(sequence.merge(alice, bob), anchor)
+  |> expect.to_equal(Ok(1))
+}
+
+pub fn resolution_agrees_across_replicas_after_merge_test() {
+  let base = abc()
+  let anchor = sequence.anchor_at(base, 2, Before)
+  let alice =
+    sequence.merge(sequence.new(rid("alice")), base)
+    |> sequence.insert(0, "x")
+  let bob =
+    sequence.merge(sequence.new(rid("bob")), base)
+    |> sequence.insert(3, "y")
+
+  sequence.resolve(sequence.merge(alice, bob), anchor)
+  |> expect.to_equal(sequence.resolve(sequence.merge(bob, alice), anchor))
+}
+
+pub fn anchor_creation_and_resolution_do_not_mutate_state_test() {
+  let seq = abc()
+  let anchor = sequence.anchor_at(seq, 1, Before)
+  let _ = sequence.resolve(seq, anchor)
+
+  // Creating and resolving anchors must not bump the counter or add items:
+  // the next insert behaves exactly as it would on an untouched sequence.
+  sequence.insert(seq, 1, "x")
+  |> expect.to_equal(sequence.insert(abc(), 1, "x"))
+}

--- a/packages/lattice_sequence/test/serialization/anchor_json_test.gleam
+++ b/packages/lattice_sequence/test/serialization/anchor_json_test.gleam
@@ -1,0 +1,107 @@
+import gleam/json
+import gleam/string
+import lattice_core/replica_id
+import lattice_sequence/sequence.{After, Before}
+import startest/expect
+
+fn rid(id: String) {
+  replica_id.new(id)
+}
+
+fn ab() {
+  sequence.new(rid("A"))
+  |> sequence.insert(0, "a")
+  |> sequence.insert(1, "b")
+}
+
+fn round_trip(
+  anchor: sequence.Anchor,
+) -> Result(sequence.Anchor, json.DecodeError) {
+  json.to_string(sequence.anchor_to_json(anchor))
+  |> sequence.anchor_from_json()
+}
+
+pub fn start_anchor_round_trip_test() {
+  round_trip(sequence.start_anchor())
+  |> expect.to_equal(Ok(sequence.start_anchor()))
+}
+
+pub fn end_anchor_round_trip_test() {
+  round_trip(sequence.end_anchor())
+  |> expect.to_equal(Ok(sequence.end_anchor()))
+}
+
+pub fn item_anchor_before_bias_round_trip_test() {
+  let anchor = sequence.anchor_at(ab(), 1, Before)
+  round_trip(anchor) |> expect.to_equal(Ok(anchor))
+}
+
+pub fn item_anchor_after_bias_round_trip_test() {
+  let anchor = sequence.anchor_at(ab(), 1, After)
+  round_trip(anchor) |> expect.to_equal(Ok(anchor))
+}
+
+pub fn anchor_json_uses_versioned_envelope_test() {
+  let json_string =
+    json.to_string(sequence.anchor_to_json(sequence.start_anchor()))
+
+  json_string |> string.contains("\"type\":\"anchor\"") |> expect.to_be_true()
+  json_string |> string.contains("\"v\":1") |> expect.to_be_true()
+}
+
+pub fn decoded_anchor_resolves_on_the_sequence_test() {
+  let seq = ab()
+  let assert Ok(anchor) = round_trip(sequence.anchor_at(seq, 1, Before))
+
+  sequence.resolve(seq, anchor) |> expect.to_equal(1)
+}
+
+pub fn anchor_from_json_wrong_type_rejected_test() {
+  let payload =
+    "{\"type\":\"sequence\",\"v\":1,\"anchor\":{\"kind\":\"start\"}}"
+  case sequence.anchor_from_json(payload) {
+    Error(_) -> expect.to_be_true(True)
+    Ok(_) -> expect.to_be_true(False)
+  }
+}
+
+pub fn anchor_from_json_wrong_version_rejected_test() {
+  let payload = "{\"type\":\"anchor\",\"v\":2,\"anchor\":{\"kind\":\"start\"}}"
+  case sequence.anchor_from_json(payload) {
+    Error(_) -> expect.to_be_true(True)
+    Ok(_) -> expect.to_be_true(False)
+  }
+}
+
+pub fn anchor_from_json_unknown_kind_rejected_test() {
+  let payload = "{\"type\":\"anchor\",\"v\":1,\"anchor\":{\"kind\":\"middle\"}}"
+  case sequence.anchor_from_json(payload) {
+    Error(_) -> expect.to_be_true(True)
+    Ok(_) -> expect.to_be_true(False)
+  }
+}
+
+pub fn anchor_from_json_invalid_bias_rejected_test() {
+  let payload =
+    "{\"type\":\"anchor\",\"v\":1,\"anchor\":{\"kind\":\"item\",\"id\":{\"replica_id\":\"A\",\"counter\":1},\"bias\":\"sideways\"}}"
+  case sequence.anchor_from_json(payload) {
+    Error(_) -> expect.to_be_true(True)
+    Ok(_) -> expect.to_be_true(False)
+  }
+}
+
+pub fn anchor_from_json_negative_counter_rejected_test() {
+  let payload =
+    "{\"type\":\"anchor\",\"v\":1,\"anchor\":{\"kind\":\"item\",\"id\":{\"replica_id\":\"A\",\"counter\":-1},\"bias\":\"before\"}}"
+  case sequence.anchor_from_json(payload) {
+    Error(_) -> expect.to_be_true(True)
+    Ok(_) -> expect.to_be_true(False)
+  }
+}
+
+pub fn anchor_from_json_malformed_json_rejected_test() {
+  case sequence.anchor_from_json("not json") {
+    Error(_) -> expect.to_be_true(True)
+    Ok(_) -> expect.to_be_true(False)
+  }
+}

--- a/packages/lattice_text/README.md
+++ b/packages/lattice_text/README.md
@@ -1,0 +1,60 @@
+# lattice_text
+
+Plain-text CRDT for Gleam using YATA-style left/right origins.
+
+Use this package when replicas need to edit shared text concurrently and converge without coordination. All operations are grapheme-based, so emoji and combining sequences count as one unit. For a generic list CRDT, use `lattice_sequence` directly.
+
+## Installation
+
+```sh
+gleam add lattice_text
+```
+
+## Quick example
+
+```gleam
+import lattice_core/replica_id
+import lattice_text/text
+
+pub fn main() {
+  let node_a =
+    text.new(replica_id.new("node-a"))
+    |> text.insert(0, "Hello world")
+
+  let node_b =
+    text.new(replica_id.new("node-b"))
+    |> text.append("!")
+
+  let merged = text.merge(node_a, node_b)
+
+  text.value(merged)
+  // -> "Hello world!"
+}
+```
+
+## Modules
+
+| Module | Purpose |
+|--------|---------|
+| `lattice_text/text` | Grapheme-based text CRDT with editing, range, and delta operations. |
+
+## Notes
+
+- Editing operations: `insert`, `delete`, `delete_range`, `replace_range`, `move`, and `append`.
+- Query helpers: `value`, `values`, `length`, `substring`, and `try_substring`.
+- Fallible operations have `try_*` variants returning `Result`; the plain variants assert on invalid indexes. Range operations return `RangeError` when `0 <= start <= end <= length` does not hold.
+- Delta-state variants (`*_with_delta`) return the updated text plus a delta that can be merged into other replicas, avoiding full-state sync.
+- Cursor anchors: `anchor_at` creates a stable position that survives concurrent edits and merges, `resolve_anchor` maps it back to a current grapheme index, and `anchor_to_json`/`anchor_from_json` let anchors travel between replicas (e.g. shared cursors).
+- `merge`, `to_json`, and `from_json` round-trip the full CRDT state using the canonical sequence JSON envelope.
+- Backed by `lattice_sequence` stable item IDs, so concurrent edits converge deterministically on both Erlang and JavaScript targets.
+
+## Links
+
+- Project site: <https://lattice.tylerbutler.com>
+- API docs: <https://hexdocs.pm/lattice_text>
+- Hex package: <https://hex.pm/packages/lattice_text>
+- Repository: <https://github.com/tylerbutler/lattice>
+
+## License
+
+MIT

--- a/packages/lattice_text/src/lattice_text/text.gleam
+++ b/packages/lattice_text/src/lattice_text/text.gleam
@@ -366,6 +366,88 @@ pub fn try_move_with_delta(
   }
 }
 
+/// Create an anchor at the start of the text. Always resolves to 0.
+pub fn start_anchor() -> sequence.Anchor {
+  sequence.start_anchor()
+}
+
+/// Create an anchor at the end of the text. Always resolves to the current
+/// grapheme length, tracking growth.
+pub fn end_anchor() -> sequence.Anchor {
+  sequence.end_anchor()
+}
+
+/// Create an anchor at the gap before the grapheme at `index`.
+///
+/// Anchors are stable positions that survive concurrent edits and merges:
+/// resolve one back to a current grapheme index with `resolve_anchor`.
+/// `Before` bias glues the anchor to the grapheme at `index`, so inserts at
+/// the gap push it right; `After` bias glues it to the grapheme at
+/// `index - 1`, so inserts at the gap land after it.
+///
+/// ## Examples
+///
+/// ```gleam
+/// let doc = text.new(replica_id.new("A")) |> text.insert(0, "hello")
+/// let cursor = text.anchor_at(doc, 5, sequence.After)
+/// let doc = text.insert(doc, 0, "say ")
+/// text.resolve_anchor(doc, cursor)  // -> 9
+/// ```
+pub fn anchor_at(
+  text: Text,
+  index: Int,
+  bias: sequence.Bias,
+) -> sequence.Anchor {
+  let assert Ok(anchor) = try_anchor_at(text, index, bias)
+  anchor
+}
+
+/// Safely create an anchor at the gap before the grapheme at `index`.
+///
+/// Valid positions are `0 <= index <= length`.
+pub fn try_anchor_at(
+  text: Text,
+  index: Int,
+  bias: sequence.Bias,
+) -> Result(sequence.Anchor, sequence.AnchorError) {
+  let Text(seq) = text
+  sequence.try_anchor_at(seq, index, bias)
+}
+
+/// Resolve an anchor to a current grapheme index in `[0, length]`.
+///
+/// Anchors on deleted graphemes still resolve: they collapse to the gap
+/// where the grapheme used to be. Anchors follow moved graphemes.
+pub fn resolve_anchor(text: Text, anchor: sequence.Anchor) -> Int {
+  let assert Ok(index) = try_resolve_anchor(text, anchor)
+  index
+}
+
+/// Safely resolve an anchor to a current grapheme index in `[0, length]`.
+///
+/// Returns `Error(UnknownAnchorTarget)` when the anchor references a
+/// grapheme this replica has never seen (created remotely and not yet
+/// merged).
+pub fn try_resolve_anchor(
+  text: Text,
+  anchor: sequence.Anchor,
+) -> Result(Int, sequence.AnchorError) {
+  let Text(seq) = text
+  sequence.try_resolve(seq, anchor)
+}
+
+/// Encode an anchor as a self-describing JSON value.
+pub fn anchor_to_json(anchor: sequence.Anchor) -> json.Json {
+  sequence.anchor_to_json(anchor)
+}
+
+/// Decode an anchor from a JSON string produced by `anchor_to_json`.
+pub fn anchor_from_json(
+  json_string: String,
+) -> Result(sequence.Anchor, json.DecodeError) {
+  sequence.anchor_from_json(json_string)
+}
+
 /// Insert a value at the end of the text. Appending is always valid, so no
 /// `try_` variant exists.
 ///

--- a/packages/lattice_text/test/property/anchor_property_test.gleam
+++ b/packages/lattice_text/test/property/anchor_property_test.gleam
@@ -1,0 +1,124 @@
+import lattice_core/replica_id
+import lattice_sequence/sequence.{type Bias, After, Before}
+import lattice_text/text
+import qcheck
+import startest/expect
+
+fn rid(id: String) {
+  replica_id.new(id)
+}
+
+fn small_test_config() -> qcheck.Config {
+  qcheck.config(test_count: 10, max_retries: 3, seed: qcheck.seed(42))
+}
+
+fn doc(value: String) {
+  text.new(rid("A"))
+  |> text.insert(0, value)
+}
+
+fn bias_from_int(n: Int) -> Bias {
+  case n % 2 {
+    0 -> Before
+    _ -> After
+  }
+}
+
+pub fn anchor_resolution_stays_in_bounds__test() {
+  qcheck.run(
+    small_test_config(),
+    qcheck.map3(
+      qcheck.bounded_int(0, 5),
+      qcheck.bounded_int(0, 100),
+      qcheck.bounded_int(0, 100),
+      fn(a, b, c) { #(a, b, c) },
+    ),
+    fn(triple) {
+      let #(anchor_index, insert_seed, delete_seed) = triple
+      let base = doc("abcde")
+      let anchor =
+        text.anchor_at(base, anchor_index, bias_from_int(insert_seed))
+      let inserted = text.insert(base, insert_seed % 6, "xy")
+      let updated = text.delete(inserted, delete_seed % text.length(inserted))
+
+      let resolved = text.resolve_anchor(updated, anchor)
+      expect.to_be_true(resolved >= 0 && resolved <= text.length(updated))
+      Nil
+    },
+  )
+}
+
+pub fn before_anchor_on_live_grapheme_tracks_it__test() {
+  qcheck.run(
+    small_test_config(),
+    qcheck.map3(
+      qcheck.bounded_int(0, 4),
+      qcheck.bounded_int(0, 5),
+      qcheck.bounded_int(0, 6),
+      fn(a, b, c) { #(a, b, c) },
+    ),
+    fn(triple) {
+      let #(anchor_index, first_insert, second_insert) = triple
+      let base = doc("abcde")
+      let grapheme = text.substring(base, anchor_index, anchor_index + 1)
+      let anchor = text.anchor_at(base, anchor_index, Before)
+      let updated =
+        base
+        |> text.insert(first_insert, "xx")
+        |> text.insert(second_insert, "y")
+
+      let resolved = text.resolve_anchor(updated, anchor)
+      text.substring(updated, resolved, resolved + 1)
+      |> expect.to_equal(grapheme)
+      Nil
+    },
+  )
+}
+
+pub fn create_then_resolve_is_identity__test() {
+  qcheck.run(
+    small_test_config(),
+    qcheck.map2(qcheck.bounded_int(0, 5), qcheck.bounded_int(0, 1), fn(a, b) {
+      #(a, b)
+    }),
+    fn(pair) {
+      let #(index, bias_seed) = pair
+      let base = doc("abcde")
+
+      text.resolve_anchor(
+        base,
+        text.anchor_at(base, index, bias_from_int(bias_seed)),
+      )
+      |> expect.to_equal(index)
+      Nil
+    },
+  )
+}
+
+pub fn resolution_agrees_across_replicas_after_merge__test() {
+  qcheck.run(
+    small_test_config(),
+    qcheck.map3(
+      qcheck.bounded_int(0, 5),
+      qcheck.bounded_int(0, 5),
+      qcheck.bounded_int(0, 5),
+      fn(a, b, c) { #(a, b, c) },
+    ),
+    fn(triple) {
+      let #(anchor_index, alice_insert, bob_insert) = triple
+      let base = doc("abcde")
+      let anchor =
+        text.anchor_at(base, anchor_index, bias_from_int(alice_insert))
+      let alice =
+        text.merge(text.new(rid("alice")), base)
+        |> text.insert(alice_insert, "x")
+      let bob =
+        text.merge(text.new(rid("bob")), base)
+        |> text.insert(bob_insert, "y")
+
+      text.resolve_anchor(text.merge(alice, bob), anchor)
+      |> expect.to_equal(text.resolve_anchor(text.merge(bob, alice), anchor))
+      Nil
+    },
+  )
+}

--- a/packages/lattice_text/test/text/anchor_test.gleam
+++ b/packages/lattice_text/test/text/anchor_test.gleam
@@ -1,0 +1,120 @@
+import gleam/json
+import lattice_core/replica_id
+import lattice_sequence/sequence.{After, Before}
+import lattice_text/text
+import startest/expect
+
+fn rid(id: String) {
+  replica_id.new(id)
+}
+
+fn doc(value: String) {
+  text.new(rid("A"))
+  |> text.insert(0, value)
+}
+
+pub fn start_and_end_anchors_resolve_test() {
+  let d = doc("abc")
+
+  text.resolve_anchor(d, text.start_anchor()) |> expect.to_equal(0)
+  text.resolve_anchor(d, text.end_anchor()) |> expect.to_equal(3)
+  text.resolve_anchor(text.append(d, "de"), text.end_anchor())
+  |> expect.to_equal(5)
+}
+
+pub fn anchor_shifts_with_insert_before_it_test() {
+  let d = doc("hello")
+  let anchor = text.anchor_at(d, 5, After)
+
+  text.resolve_anchor(text.insert(d, 0, "say "), anchor)
+  |> expect.to_equal(9)
+}
+
+pub fn try_anchor_at_out_of_bounds_returns_error_test() {
+  doc("abc")
+  |> text.try_anchor_at(4, Before)
+  |> expect.to_equal(
+    Error(sequence.AnchorIndexOutOfBounds(index: 4, length: 3)),
+  )
+}
+
+pub fn try_resolve_anchor_unknown_target_returns_error_test() {
+  let alice = doc("abc")
+  let bob = text.merge(text.new(rid("B")), alice) |> text.insert(1, "x")
+  let anchor = text.anchor_at(bob, 1, Before)
+
+  text.try_resolve_anchor(alice, anchor)
+  |> expect.to_equal(Error(sequence.UnknownAnchorTarget))
+  text.try_resolve_anchor(text.merge(alice, bob), anchor)
+  |> expect.to_equal(Ok(1))
+}
+
+pub fn anchor_counts_graphemes_not_codepoints_test() {
+  // "👍" and "é" are single graphemes.
+  let d = doc("a👍é")
+  let anchor = text.anchor_at(d, 3, Before)
+
+  text.resolve_anchor(d, anchor) |> expect.to_equal(3)
+  text.resolve_anchor(text.insert(d, 0, "🎉🎉"), anchor)
+  |> expect.to_equal(5)
+}
+
+pub fn multi_grapheme_insert_at_gap_respects_bias_test() {
+  let d = doc("ab")
+  let before = text.anchor_at(d, 1, Before)
+  let after = text.anchor_at(d, 1, After)
+  let updated = text.insert(d, 1, "👍👍👍")
+
+  text.resolve_anchor(updated, before) |> expect.to_equal(4)
+  text.resolve_anchor(updated, after) |> expect.to_equal(1)
+}
+
+pub fn delete_range_spanning_anchor_collapses_it_test() {
+  let d = doc("abcdef")
+  let anchor = text.anchor_at(d, 3, Before)
+  let updated = text.delete_range(d, 1, 5)
+
+  // "d" was deleted; the anchor collapses to the gap left behind.
+  text.resolve_anchor(updated, anchor) |> expect.to_equal(1)
+}
+
+pub fn replace_range_spanning_anchor_test() {
+  let d = doc("abcdef")
+  let anchor = text.anchor_at(d, 3, Before)
+  let updated = text.replace_range(d, 1, 5, "XY")
+
+  // The anchored grapheme "d" is gone; the anchor lands inside the
+  // replacement region, still within bounds.
+  let resolved = text.resolve_anchor(updated, anchor)
+  expect.to_be_true(resolved >= 0 && resolved <= text.length(updated))
+}
+
+pub fn delete_range_before_anchor_shifts_it_left_test() {
+  let d = doc("abcdef")
+  let anchor = text.anchor_at(d, 4, Before)
+
+  text.resolve_anchor(text.delete_range(d, 0, 3), anchor)
+  |> expect.to_equal(1)
+}
+
+pub fn anchor_survives_merge_of_concurrent_edits_test() {
+  let base = doc("abc")
+  let anchor = text.anchor_at(base, 2, Before)
+  let alice = text.merge(text.new(rid("alice")), base) |> text.insert(0, "x")
+  let bob = text.merge(text.new(rid("bob")), base) |> text.delete(0)
+  let merged = text.merge(alice, bob)
+
+  // Wherever "c" ends up after the merge, the anchor still points at it.
+  let resolved = text.resolve_anchor(merged, anchor)
+  text.substring(merged, resolved, resolved + 1) |> expect.to_equal("c")
+}
+
+pub fn anchor_json_round_trip_test() {
+  let d = doc("abc")
+  let anchor = text.anchor_at(d, 2, After)
+  let assert Ok(decoded) =
+    text.anchor_from_json(json.to_string(text.anchor_to_json(anchor)))
+
+  text.resolve_anchor(d, decoded) |> expect.to_equal(2)
+  decoded |> expect.to_equal(anchor)
+}


### PR DESCRIPTION
## Summary

Implements `docs/plans/text-crdt-cursor-anchoring.md`: stable position anchors that name a gap between items and survive concurrent edits and merges, so editors can keep cursors and selections in place across remote inserts and deletes.

### `lattice_sequence`

- `Bias` (`Before` / `After`) controls which side of the gap an anchor sticks to when content is inserted exactly at it.
- Opaque `Anchor` type (`Start | End | AtItem(ItemId, Bias)`) — the only public handle to item identity; `ItemId` stays opaque.
- `anchor_at` / `try_anchor_at` create an anchor from a visible index (`0 <= index <= length`); boundary positions degrade to the start/end sentinels.
- `resolve` / `try_resolve` map an anchor back to a current index. Anchors on deleted items collapse to the gap left behind (tombstones keep them resolvable); anchors follow moved items. An anchor whose item this replica has never seen resolves to `Error(UnknownAnchorTarget)` until the remote state is merged.
- `anchor_to_json` / `anchor_from_json` with a versioned envelope (`type: anchor, v: 1`) so anchors can travel between replicas (shared cursors).

### `lattice_text`

Thin grapheme-level wrappers (`anchor_at`, `resolve_anchor`, `start_anchor`/`end_anchor`, JSON codecs, plus `try_` variants) reusing the sequence types, so callers never import `lattice_sequence`.

Anchors are queries, not mutations: no counter bumps, no deltas, and `merge`/state encoding are unchanged — purely additive API.

## Testing

- Sequence unit tests: bounds and bias selection, sentinels, resolve across inserts/deletes before/at/after the gap, bias divergence at the gap, deleted-item collapse (both biases), moved-item follow, `UnknownAnchorTarget` before merge and success after, no-mutation guarantee.
- Serialization tests: round-trips for all variants, malformed envelope/kind/bias/counter rejection.
- Text unit tests: grapheme (emoji) handling, `delete_range`/`replace_range` spanning the anchor, merge survival, JSON round-trip.
- Property tests (qcheck): resolution stays in `[0, length]`, `Before` anchors track their live grapheme, create-then-resolve identity, cross-replica agreement after merge.

`just format`, `just check`, `just lint-pkg` clean; all tests pass on both Erlang and JavaScript targets. Changelog entries (minor) added for both packages.