### PR TITLE
fix(ci): stop hitting Hex API rate limit in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,28 @@ jobs:
             ${{ steps.ws.outputs.version-files }}
           post-batch-command: |
             echo "Refreshing lockfiles after version bumps..."
-            for d in packages/lattice_*/; do
-              [ -f "$d/gleam.toml" ] || continue
-              deps=$(grep -E '^lattice_[a-z_]+ = \{ path =' "$d/gleam.toml" | cut -d= -f1 | xargs || true)
-              [ -n "$deps" ] && (cd "$d" && gleam update $deps)
+
+            # Patch the locked version of each bumped local package directly in every
+            # manifest.toml that references it, instead of running `gleam update`.
+            # `gleam update` re-resolves the *entire* dependency graph against Hex even
+            # for a purely local path-dependency bump, and one such call per package
+            # reliably trips Hex's per-IP rate limit on shared GitHub runners once a
+            # release batches more than a couple of packages. A local path package's
+            # "version" in manifest.toml is just recorded metadata — writing it
+            # directly produces the exact same result with zero network calls, so this
+            # scales to any batch size.
+            changed_projects=$(git diff --name-only -- 'packages/*/gleam.toml' \
+              | sed -E 's#^packages/(lattice_[a-z_]+)/gleam\.toml$#\1#')
+            echo "Bumped projects: $(echo "$changed_projects" | tr '\n' ' ')"
+
+            for dep in $changed_projects; do
+              new_version=$(grep -m1 '^version = ' "packages/$dep/gleam.toml" | cut -d'"' -f2)
+              for manifest in packages/*/manifest.toml examples/manifest.toml; do
+                [ -f "$manifest" ] || continue
+                grep -q "{ name = \"$dep\", version = " "$manifest" || continue
+                sed -i -E "s/(\{ name = \"$dep\", version = \")[^\"]*(\")/\1${new_version}\2/" "$manifest"
+                echo "Updated $manifest: $dep -> $new_version"
+              done
             done
 
       - name: Summary


### PR DESCRIPTION
## Summary
- The release workflow's `post-batch-command` ran `gleam update` for every package with a `lattice_*` path dependency after version bumps, to refresh the locked version recorded in `manifest.toml`.
- `gleam update` re-resolves the entire dependency graph against Hex (not just the local path dep), so firing it once per dependent package sent several Hex API calls in quick succession from the same runner IP, tripping Hex's per-IP rate limit whenever a release batched more than a couple of packages — this has failed on nearly every release recently.
- Since a local path package's "version" in `manifest.toml` is just recorded metadata, the workflow now patches it directly for whichever packages were actually bumped this batch (via `git diff` against `gleam.toml`), with zero Hex/network calls. Verified against a simulated multi-package batch that this produces an identical, buildable result to what `gleam update` would have produced.