### PR TITLE
docs(text): correct storage-granularity description

### DIFF
--- a/packages/lattice_text/src/lattice_text/text.gleam
+++ b/packages/lattice_text/src/lattice_text/text.gleam
@@ -1,6 +1,8 @@
 //// A plain-text CRDT backed by `lattice_sequence`.
 ////
-//// Text stores each inserted string segment as a sequence item. Insert,
+//// Text is stored as a sequence of single-grapheme items: every inserted
+//// string is split into graphemes and each grapheme becomes one sequence
+//// item, so indices, anchors, and `length` are all grapheme-based. Insert,
 //// delete, merge, and delta operations delegate to `lattice_sequence`.
 //// Use `lattice_sequence/sequence` directly when you need a generic list CRDT.
 ////


### PR DESCRIPTION
Fixes #104.

The `lattice_text` module doc claimed "Text stores each inserted string segment as a sequence item," but `try_insert_with_delta` splits every value into graphemes and stores **one item per grapheme** (`length("a👍") == 2`). Reworded to state text is stored as single-grapheme items and that indices/anchors/length are grapheme-based, matching actual behavior.

Docs-only change.