### PR TITLE
refactor(sequence): remove dead unsafe covered-move stabilization branch

### DIFF
--- a/packages/lattice_sequence/src/lattice_sequence/sequence.gleam
+++ b/packages/lattice_sequence/src/lattice_sequence/sequence.gleam
@@ -826,23 +826,19 @@ fn reconcile_element(
 }
 
 /// One side has the element compacted into a block, the other still holds a
-/// live item for it. A tombstone or an uncovered (still volatile) move
-/// supersedes the block slot; a plain copy — or one whose move the merged
-/// frontier already covers, meaning the block slot reflects its settled
-/// position — collapses to the stable representation. The rule looks only
-/// at the live item and the merged frontier, so both merge directions agree.
-fn stable_or_live(item: Item(a), frontier: VersionVector) -> Element(a) {
-  case item.deleted {
-    Some(_) -> LiveEl(item)
-    None ->
-      case item.move {
-        None -> Stable(id: item.id, value: item.value)
-        Some(Move(op, _, _)) ->
-          case frontier_covers_op(frontier, op) {
-            True -> Stable(id: item.id, value: item.value)
-            False -> LiveEl(item)
-          }
-      }
+/// live item for it. A tombstone or a move keeps the item live and supersedes
+/// the block slot; only a plain copy collapses to the stable representation.
+/// The rule looks only at the live item, so both merge directions agree.
+///
+/// A moved item is never collapsed into the block skeleton, even if the merged
+/// frontier covers its move op: `compact` refuses to stabilize any state that
+/// holds a move (see `compact`), so a covered-move block slot cannot legitimately
+/// arise, and baking one here would strip the origins a peer's concurrent
+/// above-frontier inserts integrate against and break merge commutativity.
+fn stable_or_live(item: Item(a), _frontier: VersionVector) -> Element(a) {
+  case item.deleted, item.move {
+    None, None -> Stable(id: item.id, value: item.value)
+    _, _ -> LiveEl(item)
   }
 }
 
@@ -1087,12 +1083,17 @@ fn compare_lamport(x: Item(a), y: Item(a)) -> order.Order {
 /// Compacting at the current frontier, at an older one, or at one concurrent
 /// with it is a no-op — frontiers only advance.
 ///
-/// A state currently holding any move record is also left unchanged:
-/// stabilizing moved geometry would bake the displacement into the compact
-/// skeleton while uncompacted peers still order concurrent edits against
-/// the pre-move positions. Moves merged in AFTER compaction are fine — they
-/// re-place items without touching the compacted skeleton — so hosts using
-/// `move` compact during move-free windows.
+/// A state holding ANY move record is left unchanged, even when the move op is
+/// already covered by `stable`. This guard is load-bearing for convergence, not
+/// just conservatism: baking a settled move into the compact skeleton fixes its
+/// position from only the compacting replica's items, but a peer's still-live
+/// concurrent inserts above the frontier integrate against the moved item's
+/// origins — which stabilization strips. The two then order those inserts
+/// differently and `merge` stops commuting (see the property test
+/// `merge_commutes_with_compaction_for_deltas_above_frontier`). Because move
+/// records are never cleared locally, a replica that uses `move` cannot compact
+/// until it merges a peer that has already stabilized the item into a block; a
+/// safe stabilization path for moves is future work (see issue #98).
 pub fn compact(
   sequence: Sequence(a),
   stable: VersionVector,

--- a/packages/lattice_sequence/test/sequence/compact_test.gleam
+++ b/packages/lattice_sequence/test/sequence/compact_test.gleam
@@ -118,9 +118,16 @@ pub fn compact_does_not_merge_blocks_across_counter_gaps_test() {
 }
 
 pub fn compact_is_noop_while_move_records_exist_test() {
-  // Stabilizing moved geometry would bake the displacement into the compact
-  // skeleton while uncompacted peers still order concurrent edits against
-  // pre-move positions, so a state holding move records is left unchanged.
+  // A state holding a move record is left unchanged EVEN when the move op is
+  // covered by the frontier (here frontier_a(4) covers the move's counter 4).
+  // This is load-bearing for convergence, not mere conservatism: baking the
+  // moved position into the skeleton strips the moved item's origins, so a
+  // peer's concurrent above-frontier inserts would integrate against the
+  // baked item differently depending on merge order and `merge` would stop
+  // commuting. See the property test
+  // `merge_commutes_with_compaction_for_deltas_above_frontier`, and issue #98
+  // for a safe move-stabilization path. Do not relax this to "in-flight moves
+  // only" without first making stabilized moves converge.
   let seq = abc() |> sequence.move(0, 2)
   let #(compacted, forwardings) = sequence.compact(seq, frontier_a(4))
 


### PR DESCRIPTION
Refs #98 (does **not** close it — see below).

## What this started as

#98 proposed relaxing `compact`'s move guard so a replica could compact once a move op is causally stable (key on **in-flight** moves only), which would also activate the `item_stability` / `stable_or_live` "covered move → stabilize" branches that currently look intended but are unreachable.

## Why that fix is unsafe (and this PR does something narrower)

I implemented the relaxed guard with a failing-test-first (TDD) approach. The existing property test **`merge_commutes_with_compaction_for_deltas_above_frontier` immediately falsified it** (shrunk counterexample `seed #(2,0)`):

- baking a settled move into the compact skeleton fixes the moved item's position from **only the compacting replica's items** and strips its origins;
- a move-free peer's **above-frontier concurrent inserts** then integrate against the baked item differently depending on merge order;
- `merge` stops commuting → silent divergence.

So the blanket guard is **load-bearing for convergence**, not conservatism. #98 and #99 are coupled: covered-move stabilization cannot be turned on without a deeper redesign that preserves the moved item's ordering geometry.

## What this PR actually does (behavior-preserving)

- Collapses `stable_or_live`'s unreachable covered-move → `Stable` branch to its only safe form (a tombstoned **or moved** item always stays live) and rewrites its doc comment, which previously claimed the opposite.
- Rewrites `compact`'s docstring to describe the guard accurately, explain why it must stay, and note that a safe move-stabilization path remains open.
- Strengthens the `compact_is_noop_while_move_records_exist_test` comment so this is not re-attempted without addressing convergence first.

No behavior change: **107 tests pass on both Erlang and JavaScript targets**, including the property suite that rejected the aggressive version.

## Follow-up for #98

The original complaint stands (move records are sticky, so move-using replicas can accumulate unbounded tombstones/origins and never GC), but it needs a design that lets a settled move be represented without discarding the geometry concurrent inserts rely on. Left open in #98.
