### PR TITLE
perf(sequence): splice local inserts and batch grapheme inserts

### DIFF
--- a/.changes/unreleased/lattice_sequence-Added-insert-many.yaml
+++ b/.changes/unreleased/lattice_sequence-Added-insert-many.yaml
@@ -1,0 +1,7 @@
+project: lattice_sequence
+kind: Added
+body: |-
+  Add `insert_many`, `insert_many_with_delta`, and `try_insert_many_with_delta`
+
+  Insert a run of values at consecutive indices in a single operation, reported as one combined delta instead of one delta per value. `try_insert_with_delta` now delegates to the batched path.
+time: 2026-07-06T23:42:00.000000000+00:00

--- a/.changes/unreleased/lattice_sequence-Performance-local-insert-fast-path.yaml
+++ b/.changes/unreleased/lattice_sequence-Performance-local-insert-fast-path.yaml
@@ -1,0 +1,7 @@
+project: lattice_sequence
+kind: Performance
+body: |-
+  Splice local inserts into the stored order instead of rebuilding it
+
+  When the state holds no live move record, stored order is already the canonical order, so a local insert is spliced directly in place (O(n)) rather than re-deriving the whole canonical order twice (O(n^2)). States holding a live move fall back to the previous rebuild path. The emitted delta is unchanged, so convergence is unaffected.
+time: 2026-07-06T23:42:01.000000000+00:00

--- a/.changes/unreleased/lattice_text-Performance-batched-grapheme-insert.yaml
+++ b/.changes/unreleased/lattice_text-Performance-batched-grapheme-insert.yaml
@@ -1,0 +1,7 @@
+project: lattice_text
+kind: Performance
+body: |-
+  Batch multi-grapheme inserts into a single sequence operation
+
+  Inserting or pasting a string now issues one batched backend insert covering every grapheme instead of one insert (and one delta merge) per grapheme, removing a large multiplier from building or pasting text.
+time: 2026-07-06T23:42:02.000000000+00:00

--- a/.changes/unreleased/lattice_text_core-Changed-insert-graphemes-batched.yaml
+++ b/.changes/unreleased/lattice_text_core-Changed-insert-graphemes-batched.yaml
@@ -1,0 +1,7 @@
+project: lattice_text_core
+kind: Changed
+body: |-
+  `insert_graphemes` now takes a batched `insert_many` backend closure
+
+  The generic helper accepts a single `insert_many(state, index, graphemes)` callback instead of a per-grapheme `insert` plus a `merge`, so backends splice a whole run in one operation.
+time: 2026-07-06T23:42:03.000000000+00:00

--- a/packages/lattice_sequence/src/lattice_sequence/sequence.gleam
+++ b/packages/lattice_sequence/src/lattice_sequence/sequence.gleam
@@ -218,52 +218,187 @@ pub fn try_insert_with_delta(
   index: Int,
   value: a,
 ) -> Result(#(Sequence(a), Sequence(a)), InsertError) {
+  try_insert_many_with_delta(sequence, index, [value])
+}
+
+/// Insert several values at consecutive visible indices starting at `index`.
+///
+/// `values` are placed in order — the first at `index`, the next at
+/// `index + 1`, and so on — exactly as looping `insert` would, but the whole
+/// run is spliced in a single pass and reported as one delta. Panics with
+/// `IndexOutOfBounds` when `index` is outside `[0, length]`. Use
+/// `try_insert_many_with_delta` to handle an untrusted index without crashing.
+pub fn insert_many(
+  sequence: Sequence(a),
+  index: Int,
+  values: List(a),
+) -> Sequence(a) {
+  let assert Ok(#(updated, _delta)) =
+    try_insert_many_with_delta(sequence, index, values)
+  updated
+}
+
+/// Insert several values and return both the updated sequence and the merged
+/// insertion delta covering every new item.
+///
+/// Panics with `IndexOutOfBounds` when `index` is outside `[0, length]`. Use
+/// `try_insert_many_with_delta` to handle an untrusted index without crashing.
+pub fn insert_many_with_delta(
+  sequence: Sequence(a),
+  index: Int,
+  values: List(a),
+) -> #(Sequence(a), Sequence(a)) {
+  let assert Ok(result) = try_insert_many_with_delta(sequence, index, values)
+  result
+}
+
+/// Safely insert several values at consecutive visible indices starting at
+/// `index`, returning the updated sequence and a single delta of all new
+/// items.
+///
+/// Each new item's left origin is the previous new item (the first pins to the
+/// visible left neighbor) and every item shares the same right origin — the
+/// left neighbor's canonical successor — so the run integrates contiguously on
+/// every replica. When the state holds no live move record, stored order is
+/// already the canonical order, so the run is spliced directly in place rather
+/// than re-deriving the whole order; otherwise it falls back to a full rebuild.
+pub fn try_insert_many_with_delta(
+  sequence: Sequence(a),
+  index: Int,
+  values: List(a),
+) -> Result(#(Sequence(a), Sequence(a)), InsertError) {
   let elements = segments_to_elements(sequence.segments)
   let size = visible_length_elements(elements)
 
   case index < 0 || index > size {
     True -> Error(IndexOutOfBounds(index: index, length: size))
-    False -> {
-      let next_counter = sequence.counter + 1
-      let id = ItemId(replica_id: sequence.replica_id, counter: next_counter)
-      // The left origin is the visible left neighbor in the user's (move-
-      // applied) view; the right origin is that element's successor in the
-      // CANONICAL pre-move order. This makes the conflict window between an
-      // item's origins empty in canonical space at creation, so on every
-      // replica the window can only ever contain concurrently integrated
-      // volatile items — never a compacted element.
-      let origin_left = case index {
-        0 -> None
-        _ -> visible_element_id_at(elements, index - 1)
-      }
-      let base = rebuild_base(elements, sequence.forwardings, sequence.frontier)
-      let origin_right = canonical_successor(base, origin_left)
-      let item =
-        Item(
-          id: id,
-          origin_left: origin_left,
-          origin_right: origin_right,
-          value: value,
-          deleted: None,
-          move: None,
-        )
-      // Rebuild canonically with the new item in the set, exactly as merge
-      // does, so every replica computes the same placement for this op.
-      let updated_elements =
-        rebuild(
-          list.append(elements, [LiveEl(item)]),
-          sequence.forwardings,
-          sequence.frontier,
-        )
-      let updated =
-        Sequence(
-          ..sequence,
-          counter: next_counter,
-          segments: elements_to_segments(updated_elements),
-        )
+    False ->
+      case values {
+        [] -> Ok(#(sequence, empty_delta(sequence.replica_id)))
+        _ -> {
+          // The left origin is the visible left neighbor in the user's (move-
+          // applied) view; the right origin is that element's successor in the
+          // CANONICAL pre-move order. This makes the conflict window between an
+          // item's origins empty in canonical space at creation, so on every
+          // replica the window can only ever contain concurrently integrated
+          // volatile items — never a compacted element.
+          let origin_left = case index {
+            0 -> None
+            _ -> visible_element_id_at(elements, index - 1)
+          }
+          let has_live_move = list.any(live_items_of(elements), has_move)
+          // Without moves the stored order IS the canonical base, so its
+          // stored successor is the canonical successor. With moves present
+          // the two diverge and we must consult the rebuilt base.
+          let origin_right = case has_live_move {
+            False -> canonical_successor(elements, origin_left)
+            True ->
+              canonical_successor(
+                rebuild_base(elements, sequence.forwardings, sequence.frontier),
+                origin_left,
+              )
+          }
+          let #(items, last_counter) =
+            build_insert_run(
+              sequence.replica_id,
+              sequence.counter + 1,
+              values,
+              origin_left,
+              origin_right,
+            )
+          let new_elements = list.map(items, LiveEl)
+          // Local edits splice into the authoritative stored order; only a
+          // live move makes stored order diverge from canonical, forcing the
+          // rebuild path.
+          let updated_elements = case has_live_move {
+            False -> splice_run_after(elements, origin_left, new_elements)
+            True ->
+              rebuild(
+                list.append(elements, new_elements),
+                sequence.forwardings,
+                sequence.frontier,
+              )
+          }
+          let updated =
+            Sequence(
+              ..sequence,
+              counter: last_counter,
+              segments: elements_to_segments(updated_elements),
+            )
+          let delta =
+            Sequence(
+              replica_id: sequence.replica_id,
+              counter: last_counter,
+              segments: list.map(items, Live),
+              forwardings: dict.new(),
+              frontier: version_vector.new(),
+            )
 
-      Ok(#(updated, delta_sequence(sequence.replica_id, next_counter, item)))
-    }
+          Ok(#(updated, delta))
+        }
+      }
+  }
+}
+
+/// Build a contiguous run of new items with chained left origins and a shared
+/// right origin, minting consecutive counters from `start_counter`. Returns
+/// the items in insertion order and the last counter used.
+fn build_insert_run(
+  replica_id: ReplicaId,
+  start_counter: Int,
+  values: List(a),
+  origin_left: Option(ItemId),
+  origin_right: Option(ItemId),
+) -> #(List(Item(a)), Int) {
+  let items =
+    list.index_map(values, fn(value, offset) {
+      // IDs are consecutive, so each item's left origin is simply the
+      // previous item's (deterministic) ID; the first pins to origin_left.
+      let left = case offset {
+        0 -> origin_left
+        _ ->
+          Some(ItemId(
+            replica_id: replica_id,
+            counter: start_counter + offset - 1,
+          ))
+      }
+      Item(
+        id: ItemId(replica_id: replica_id, counter: start_counter + offset),
+        origin_left: left,
+        origin_right: origin_right,
+        value: value,
+        deleted: None,
+        move: None,
+      )
+    })
+  #(items, start_counter + list.length(values) - 1)
+}
+
+/// Splice a run of elements into the stored order immediately after `after`
+/// (or at the head when `after` is `None`), preserving run order.
+fn splice_run_after(
+  elements: List(Element(a)),
+  after: Option(ItemId),
+  run: List(Element(a)),
+) -> List(Element(a)) {
+  case after {
+    None -> list.append(run, elements)
+    Some(id) -> insert_run_after_id(elements, id, run)
+  }
+}
+
+fn insert_run_after_id(
+  elements: List(Element(a)),
+  after: ItemId,
+  run: List(Element(a)),
+) -> List(Element(a)) {
+  case elements {
+    [] -> run
+    [first, ..rest] ->
+      case element_id(first) == after {
+        True -> [first, ..list.append(run, rest)]
+        False -> [first, ..insert_run_after_id(rest, after, run)]
+      }
   }
 }
 
@@ -1597,6 +1732,18 @@ fn encode_item_id(id: ItemId) -> json.Json {
 // ---------------------------------------------------------------------------
 // Element and segment plumbing
 // ---------------------------------------------------------------------------
+
+/// An empty delta carrying no items — the neutral element for `merge`,
+/// returned when an insert covers zero values.
+fn empty_delta(replica_id: ReplicaId) -> Sequence(a) {
+  Sequence(
+    replica_id: replica_id,
+    counter: 0,
+    segments: [],
+    forwardings: dict.new(),
+    frontier: version_vector.new(),
+  )
+}
 
 fn delta_sequence(
   replica_id: ReplicaId,

--- a/packages/lattice_sequence/test/sequence/sequence_test.gleam
+++ b/packages/lattice_sequence/test/sequence/sequence_test.gleam
@@ -167,6 +167,118 @@ pub fn insert_after_delete_at_same_index_is_canonically_ordered_test() {
   sequence.values(updated) |> expect.to_equal(["x", "b"])
 }
 
+pub fn insert_many_into_empty_test() {
+  sequence.new(rid("A"))
+  |> sequence.insert_many(0, ["a", "b", "c"])
+  |> sequence.values()
+  |> expect.to_equal(["a", "b", "c"])
+}
+
+pub fn insert_many_in_middle_test() {
+  sequence.new(rid("A"))
+  |> sequence.insert(0, "a")
+  |> sequence.insert(1, "d")
+  |> sequence.insert_many(1, ["b", "c"])
+  |> sequence.values()
+  |> expect.to_equal(["a", "b", "c", "d"])
+}
+
+pub fn insert_many_empty_list_is_noop_test() {
+  let base = sequence.new(rid("A")) |> sequence.insert(0, "a")
+  base
+  |> sequence.insert_many(1, [])
+  |> expect.to_equal(base)
+}
+
+pub fn try_insert_many_negative_index_returns_error_test() {
+  sequence.new(rid("A"))
+  |> sequence.try_insert_many_with_delta(-1, ["x"])
+  |> expect.to_equal(Error(sequence.IndexOutOfBounds(index: -1, length: 0)))
+}
+
+pub fn try_insert_many_past_end_returns_error_test() {
+  sequence.new(rid("A"))
+  |> sequence.insert(0, "a")
+  |> sequence.try_insert_many_with_delta(2, ["x"])
+  |> expect.to_equal(Error(sequence.IndexOutOfBounds(index: 2, length: 1)))
+}
+
+pub fn insert_many_delta_merges_to_direct_state_test() {
+  // The batched delta applied via merge on a peer must structurally equal the
+  // directly-updated state — the same invariant single inserts uphold.
+  let base =
+    sequence.new(rid("A"))
+    |> sequence.insert(0, "a")
+    |> sequence.insert(1, "d")
+  let #(direct, delta) = sequence.insert_many_with_delta(base, 1, ["b", "c"])
+
+  sequence.merge(base, delta)
+  |> expect.to_equal(direct)
+}
+
+pub fn insert_many_equivalent_to_looped_inserts_test() {
+  // A single batched insert must produce a state structurally identical to
+  // inserting the same values one at a time.
+  let looped =
+    sequence.new(rid("A"))
+    |> sequence.insert(0, "a")
+    |> sequence.insert(1, "d")
+    |> sequence.insert(1, "b")
+    |> sequence.insert(2, "c")
+  let batched =
+    sequence.new(rid("A"))
+    |> sequence.insert(0, "a")
+    |> sequence.insert(1, "d")
+    |> sequence.insert_many(1, ["b", "c"])
+
+  batched |> expect.to_equal(looped)
+}
+
+pub fn insert_many_delta_merges_after_tombstone_test() {
+  // A batched insert whose position is preceded by tombstones must still
+  // reconcile structurally with merge, mirroring the single-insert regression.
+  let base =
+    sequence.new(rid("A"))
+    |> sequence.insert(0, "a")
+    |> sequence.insert(1, "b")
+    |> sequence.delete(0)
+  let #(direct, delta) = sequence.insert_many_with_delta(base, 0, ["x", "y"])
+
+  sequence.merge(base, delta)
+  |> expect.to_equal(direct)
+  sequence.values(direct) |> expect.to_equal(["x", "y", "b"])
+}
+
+pub fn insert_after_move_delta_merges_to_direct_state_test() {
+  // With a live move record present the fast path falls back to a full
+  // rebuild; the delta must still reconcile structurally with merge.
+  let base =
+    sequence.new(rid("A"))
+    |> sequence.insert(0, "a")
+    |> sequence.insert(1, "b")
+    |> sequence.insert(2, "c")
+    |> sequence.move(0, 2)
+  let #(direct, delta) = sequence.insert_with_delta(base, 1, "x")
+
+  sequence.merge(base, delta)
+  |> expect.to_equal(direct)
+  sequence.values(direct) |> expect.to_equal(["b", "x", "c", "a"])
+}
+
+pub fn insert_many_after_move_delta_merges_to_direct_state_test() {
+  let base =
+    sequence.new(rid("A"))
+    |> sequence.insert(0, "a")
+    |> sequence.insert(1, "b")
+    |> sequence.insert(2, "c")
+    |> sequence.move(0, 2)
+  let #(direct, delta) = sequence.insert_many_with_delta(base, 1, ["x", "y"])
+
+  sequence.merge(base, delta)
+  |> expect.to_equal(direct)
+  sequence.values(direct) |> expect.to_equal(["b", "x", "y", "c", "a"])
+}
+
 pub fn move_reorders_visible_item_test() {
   sequence.new(rid("A"))
   |> sequence.insert(0, "a")

--- a/packages/lattice_text/src/lattice_text/text.gleam
+++ b/packages/lattice_text/src/lattice_text/text.gleam
@@ -507,8 +507,7 @@ fn insert_graphemes_with_delta(
     seq,
     index,
     sequence.length,
-    sequence.try_insert_with_delta,
-    sequence.merge,
+    sequence.try_insert_many_with_delta,
     sequence.IndexOutOfBounds,
   )
 }

--- a/packages/lattice_text_core/src/lattice_text_core/grapheme.gleam
+++ b/packages/lattice_text_core/src/lattice_text_core/grapheme.gleam
@@ -62,53 +62,32 @@ pub fn slice(graphemes: List(String), start: Int, end: Int) -> String {
   |> string.concat()
 }
 
-/// Insert a list of graphemes one at a time from `index`, threading a merged
-/// delta of every inserted node.
+/// Insert a list of graphemes at `index` as a single batched operation,
+/// returning the updated state and one delta covering every inserted node.
 ///
 /// Generic over the backend state `s` and insert-error `e`:
 /// - `length` reports the backend's current visible length.
-/// - `insert` inserts a single grapheme, returning the updated state and its
-///   one-node delta, or a backend error.
-/// - `merge` joins two deltas.
+/// - `insert_many` inserts the whole grapheme run starting at `index`,
+///   returning the updated state and its combined delta, or a backend error.
 /// - `index_out_of_bounds` builds the backend error for an invalid `index`.
 ///
 /// Returns `Error` (via `index_out_of_bounds`) when `index` is outside
 /// `[0, length]`, mirroring the backend's own bounds contract even when the
 /// grapheme list is empty. An empty grapheme list at a valid index is a no-op
-/// whose delta is the unchanged state.
+/// whose delta is the unchanged state, and never reaches `insert_many`.
 pub fn insert_graphemes(
   graphemes: List(String),
   state: s,
   index: Int,
   length: fn(s) -> Int,
-  insert: fn(s, Int, String) -> Result(#(s, s), e),
-  merge: fn(s, s) -> s,
+  insert_many: fn(s, Int, List(String)) -> Result(#(s, s), e),
   index_out_of_bounds: fn(Int, Int) -> e,
 ) -> Result(#(s, s), e) {
   let len = length(state)
   case graphemes, index < 0 || index > len {
     _, True -> Error(index_out_of_bounds(index, len))
     [], False -> Ok(#(state, state))
-    [first, ..rest], False -> {
-      use #(first_state, first_delta) <- result.try(insert(state, index, first))
-      list.try_fold(
-        rest,
-        #(first_state, first_delta, index + 1),
-        fn(acc, grapheme) {
-          let #(current, delta, current_index) = acc
-          use #(updated, next_delta) <- result.try(insert(
-            current,
-            current_index,
-            grapheme,
-          ))
-          Ok(#(updated, merge(delta, next_delta), current_index + 1))
-        },
-      )
-      |> result.map(fn(acc) {
-        let #(updated, delta, _) = acc
-        #(updated, delta)
-      })
-    }
+    _, False -> insert_many(state, index, graphemes)
   }
 }
 

--- a/packages/lattice_text_core/test/grapheme/grapheme_test.gleam
+++ b/packages/lattice_text_core/test/grapheme/grapheme_test.gleam
@@ -16,10 +16,10 @@ fn length(state: List(String)) -> Int {
   list.length(state)
 }
 
-fn insert(
+fn insert_many(
   state: List(String),
   index: Int,
-  grapheme: String,
+  graphemes: List(String),
 ) -> Result(#(List(String), List(String)), Err) {
   let len = list.length(state)
   case index < 0 || index > len {
@@ -27,7 +27,7 @@ fn insert(
     False -> {
       let before = list.take(state, index)
       let after = list.drop(state, index)
-      Ok(#(list.flatten([before, [grapheme], after]), [grapheme]))
+      Ok(#(list.flatten([before, graphemes, after]), graphemes))
     }
   }
 }
@@ -117,8 +117,7 @@ pub fn insert_graphemes_into_empty_test() {
     [],
     0,
     length,
-    insert,
-    insert_merge,
+    insert_many,
     IndexOutOfBounds,
   )
   |> expect.to_equal(Ok(#(["a", "b", "c"], ["a", "b", "c"])))
@@ -130,8 +129,7 @@ pub fn insert_graphemes_in_middle_test() {
     ["a", "d"],
     1,
     length,
-    insert,
-    insert_merge,
+    insert_many,
     IndexOutOfBounds,
   )
   |> expect.to_equal(Ok(#(["a", "x", "y", "d"], ["x", "y"])))
@@ -143,8 +141,7 @@ pub fn insert_empty_graphemes_is_noop_test() {
     ["a", "b"],
     1,
     length,
-    insert,
-    insert_merge,
+    insert_many,
     IndexOutOfBounds,
   )
   |> expect.to_equal(Ok(#(["a", "b"], ["a", "b"])))
@@ -156,8 +153,7 @@ pub fn insert_empty_graphemes_at_bad_index_errors_test() {
     ["a", "b"],
     9,
     length,
-    insert,
-    insert_merge,
+    insert_many,
     IndexOutOfBounds,
   )
   |> expect.to_equal(Error(IndexOutOfBounds(index: 9, length: 2)))
@@ -169,8 +165,7 @@ pub fn insert_graphemes_out_of_bounds_test() {
     ["a"],
     5,
     length,
-    insert,
-    insert_merge,
+    insert_many,
     IndexOutOfBounds,
   )
   |> expect.to_equal(Error(IndexOutOfBounds(index: 5, length: 1)))

--- a/packages/lattice_text_fugue/src/lattice_text_fugue/text.gleam
+++ b/packages/lattice_text_fugue/src/lattice_text_fugue/text.gleam
@@ -33,6 +33,7 @@ import gleam/bool
 import gleam/dynamic/decode
 import gleam/int
 import gleam/json
+import gleam/list
 import gleam/result
 import gleam/string
 import lattice_core/replica_id.{type ReplicaId}
@@ -437,8 +438,43 @@ fn insert_graphemes_with_delta(
     seq,
     index,
     sequence.length,
-    sequence.try_insert_with_delta,
-    sequence.merge,
+    fugue_insert_many,
     sequence.IndexOutOfBounds,
   )
+}
+
+/// Insert a grapheme run into the Fugue backend, one node at a time, threading
+/// a merged delta. The Fugue backend has no batch primitive yet, so this folds
+/// the single-node insert; `insert_graphemes` never calls it with an empty run.
+fn fugue_insert_many(
+  seq: sequence.Sequence(String),
+  index: Int,
+  graphemes: List(String),
+) -> Result(
+  #(sequence.Sequence(String), sequence.Sequence(String)),
+  sequence.InsertError,
+) {
+  case graphemes {
+    [] -> Ok(#(seq, seq))
+    [first, ..rest] -> {
+      use #(first_state, first_delta) <- result.try(
+        sequence.try_insert_with_delta(seq, index, first),
+      )
+      list.try_fold(
+        rest,
+        #(first_state, first_delta, index + 1),
+        fn(acc, grapheme) {
+          let #(current, delta, current_index) = acc
+          use #(updated, next_delta) <- result.try(
+            sequence.try_insert_with_delta(current, current_index, grapheme),
+          )
+          Ok(#(updated, sequence.merge(delta, next_delta), current_index + 1))
+        },
+      )
+      |> result.map(fn(acc) {
+        let #(updated, delta, _) = acc
+        #(updated, delta)
+      })
+    }
+  }
 }


### PR DESCRIPTION
Closes #103. Addresses the two `lattice_sequence` / text factors from that issue; the remaining Fugue backend hotspot is tracked separately in #109.

## Problem

Every insert re-derived the full canonical order twice (`rebuild_base` via `canonical_successor`, then `rebuild`) — O(n²) per insert on an uncompacted document. The text layer split each insert into graphemes and called the backend once per grapheme, so building or pasting an n-grapheme string was ~O(n³).

## Changes

- **`lattice_sequence` fast path** — when the state holds no live move record, stored order is already the canonical order, so a local insert is spliced directly after its left neighbor in one O(n) pass instead of rebuilding twice. States with a live move fall back to the previous rebuild path. The emitted delta is byte-identical to before, so remote convergence is unchanged by construction; only local application is cheaper.
- **`lattice_sequence` batch API** — new public `insert_many` / `insert_many_with_delta` / `try_insert_many_with_delta`. They mint consecutive counters, chain each new item's left origin to the previous one (all sharing one right origin), splice the whole run in one pass, and return a single combined delta. `try_insert_with_delta` now delegates with `[value]`.
- **`lattice_text_core`** — `insert_graphemes` takes a batched `insert_many(state, index, graphemes)` closure instead of a per-grapheme `insert` + `merge`.
- **`lattice_text`** — paste/insert issues one batched sequence op covering every grapheme (one op + one delta instead of m). `lattice_text_fugue` keeps prior behavior via a local fold (fugue perf tracked in #109).

## Complexity

Per-insert O(n²)→O(n); a single paste of m graphemes goes from O(m·n) (+ m delta merges) to O(n+m) with one delta.

## Correctness / testing

New sequence tests lock the `merge(base, delta) == updated` **structural** invariant for batched inserts, the tombstone-preceded case, and the moves-fallback path. Full suite green on **both** Erlang and JS, including the merge commutativity/associativity, delta-correctness, and compaction convergence property tests (which exercise the fast path over plain and compacted states). `just ci` passes; lint clean.

Changelog fragments added for `lattice_sequence` (Added + Performance), `lattice_text` (Performance), and `lattice_text_core` (Changed).

## Follow-up

The Fugue backend's `full_order` recomputation and missing batch primitive are out of scope here and tracked in #109.