### PR TITLE
docs(lattice_text): fix module doc and add missing /// comments

### DIFF
--- a/packages/lattice_text/src/lattice_text/text.gleam
+++ b/packages/lattice_text/src/lattice_text/text.gleam
@@ -1,6 +1,8 @@
 //// A plain-text CRDT backed by `lattice_sequence`.
 ////
-//// Text stores each inserted string segment as a sequence item. Insert,
+//// Text is stored as a sequence of single-grapheme items: every inserted
+//// string is split into graphemes and each grapheme becomes one sequence
+//// item. Indices, anchors, and length are therefore grapheme-based. Insert,
 //// delete, merge, and delta operations delegate to `lattice_sequence`.
 //// Use `lattice_sequence/sequence` directly when you need a generic list CRDT.
 ////
@@ -35,6 +37,7 @@ pub type RangeError {
   RangeOutOfBounds(start: Int, end: Int, length: Int)
 }
 
+/// Create an empty text CRDT for a replica.
 pub fn new(replica_id: ReplicaId) -> Text {
   Text(sequence.new(replica_id))
 }
@@ -109,11 +112,13 @@ pub fn try_delete_with_delta(
   }
 }
 
+/// Return the visible graphemes as a list.
 pub fn values(text: Text) -> List(String) {
   let Text(seq) = text
   sequence.values(seq)
 }
 
+/// Return the visible text as a single string.
 pub fn value(text: Text) -> String {
   text
   |> values()


### PR DESCRIPTION
## Summary

Fixes two documentation issues in `lattice_text` found during pre-1.0 review.

- **#104** — The module doc claimed text stores "each inserted string segment as a sequence item," but every value is split into graphemes and stored one item per grapheme. Reworded to accurately describe single-grapheme storage and grapheme-based indices, anchors, and length.
- **#105** — Added missing `///` doc comments to the public `new`, `values`, and `value` functions, mirroring their documented `lattice_text_fugue` counterparts.

## Changes

- `packages/lattice_text/src/lattice_text/text.gleam`

Documentation-only; no behavior or API changes. `gleam format` and `gleam check` pass.

Closes #104
Closes #105
