### PR TITLE
chore: remove fugue package change fragments

### DIFF
--- a/.changes/unreleased/lattice_fugue-Added-anchors-and-frontier.yaml
+++ b/.changes/unreleased/lattice_fugue-Added-anchors-and-frontier.yaml
@@ -1,7 +1,0 @@
-project: lattice_fugue
-kind: Added
-body: |-
-  Add position anchors and causal frontier
-
-  Adds `Anchor`, `Bias`, and `AnchorError` types plus `start_anchor`, `end_anchor`, `anchor_at`/`try_anchor_at`, `resolve`/`try_resolve`, and `anchor_to_json`/`anchor_from_json` for stable positions that survive edits and merges. Adds `frontier`, returning the causal frontier (max node counter per replica) as a `VersionVector`. These are the features a text CRDT needs from its sequence backend; move and compaction remain out of scope.
-time: 2026-07-05T18:42:00.000000000+00:00

--- a/.changes/unreleased/lattice_fugue-Added-non-interleaving-sequence-crdt.yaml
+++ b/.changes/unreleased/lattice_fugue-Added-non-interleaving-sequence-crdt.yaml
@@ -1,7 +1,0 @@
-project: lattice_fugue
-kind: Added
-body: |-
-  Add non-interleaving sequence CRDT package
-
-  Introduces `lattice_fugue/sequence`, a state-based sequence CRDT implementing the plain Fugue algorithm (Weidner & Kleppmann, arXiv:2305.00583). Provides index-based insert/delete, mergeable deltas, generic JSON codecs, and forward non-interleaving of concurrent insertions that YATA-style ordering cannot guarantee.
-time: 2026-07-05T14:24:00.000000000+00:00

--- a/.changes/unreleased/lattice_fugue-MajorRelease-stabilize-1-0.yaml
+++ b/.changes/unreleased/lattice_fugue-MajorRelease-stabilize-1-0.yaml
@@ -1,7 +1,0 @@
-project: lattice_fugue
-kind: MajorRelease
-body: |-
-  Stable 1.0 release with a committed public API
-
-  `lattice_fugue` is now 1.0. Its non-interleaving sequence CRDT API — the plain Fugue algorithm with index-based insert and delete, mergeable deltas, generic JSON codecs, position anchors, and a causal frontier — is stable and safe to depend on. From this release on, the package follows semantic versioning, so any future breaking change will come with a new major version.
-time: 2026-07-05T22:29:00.000000000-07:00

--- a/.changes/unreleased/lattice_text_fugue-Added-fugue-backed-text.yaml
+++ b/.changes/unreleased/lattice_text_fugue-Added-fugue-backed-text.yaml
@@ -1,7 +1,0 @@
-project: lattice_text_fugue
-kind: Added
-body: |-
-  Add non-interleaving plain-text CRDT backed by lattice_fugue
-
-  Introduces `lattice_text_fugue/text`, a grapheme-based plain-text CRDT built on `lattice_fugue` and `lattice_text_core`. Concurrent insertions at the same position stay contiguous instead of interleaving. Supports the core text API (insert/delete/substring/range/replace/append), position anchors, a causal frontier, and JSON serialization. Move and compaction are intentionally out of scope.
-time: 2026-07-05T18:53:00.000000000+00:00

--- a/.changes/unreleased/lattice_text_fugue-MajorRelease-stabilize-1-0.yaml
+++ b/.changes/unreleased/lattice_text_fugue-MajorRelease-stabilize-1-0.yaml
@@ -1,7 +1,0 @@
-project: lattice_text_fugue
-kind: MajorRelease
-body: |-
-  Stable 1.0 release with a committed public API
-
-  `lattice_text_fugue` is now 1.0. Its non-interleaving plain-text CRDT API — grapheme-based insert, delete, substring, range, replace, and append operations, position anchors, a causal frontier, and JSON serialization, all backed by `lattice_fugue` and `lattice_text_core` — is stable and safe to depend on. From this release on, the package follows semantic versioning, so any future breaking change will come with a new major version.
-time: 2026-07-05T22:29:01.000000000-07:00


### PR DESCRIPTION
## Summary

Removes the unreleased changie change fragments for the `lattice_fugue` and `lattice_text_fugue` packages. We're not ready to release these packages yet, so their entries should not be batched into the next release.

## Changes

Deleted the following fragments from `.changes/unreleased/`:

- `lattice_fugue-Added-anchors-and-frontier.yaml`
- `lattice_fugue-Added-non-interleaving-sequence-crdt.yaml`
- `lattice_fugue-MajorRelease-stabilize-1-0.yaml`
- `lattice_text_fugue-Added-fugue-backed-text.yaml`
- `lattice_text_fugue-MajorRelease-stabilize-1-0.yaml`

Fragments for all other packages are left untouched.
