### PR TITLE
ci: grant actions:read to auto-tag workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: read
 
 jobs:
   auto-tag:


### PR DESCRIPTION
## Problem

The `Auto-tag release` workflow fails with `startup_failure` on every PR merge (e.g. [run 28832732187](https://github.com/tylerbutler/lattice/actions/runs/28832732187?pr=112)) — GitHub reports "This run likely failed because of a workflow file issue."

## Root cause

The reusable workflow `tylerbutler/actions/.github/workflows/auto-tag.yml` declares:

```yaml
permissions:
  contents: write
  actions: read
```

but the caller (`.github/workflows/auto-tag.yml`) only granted `contents: write`. A reusable workflow cannot be granted more permissions than its caller, so the run fails at startup before any job executes.

## Fix

Add `actions: read` to the caller's `permissions` block (needed for the `wait-for-publish` publish-run polling).