### PR TITLE
ci(workflows): track setup-gleam action at main instead of v1

### DIFF
--- a/.github/workflows/ci-shared-actions.yml.template
+++ b/.github/workflows/ci-shared-actions.yml.template
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup environment
-        uses: tylerbutler/actions/setup-gleam@v1
+        uses: tylerbutler/actions/setup-gleam@main
 
       - name: Check formatting
         run: just format-check
@@ -40,7 +40,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup environment
-        uses: tylerbutler/actions/setup-gleam@v1
+        uses: tylerbutler/actions/setup-gleam@main
 
       - name: Build documentation
         run: just docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7
 
       - name: Setup environment
-        uses: tylerbutler/actions/setup-gleam@ee7def5950abcf0a519add705a95719ab345c05e # ratchet:tylerbutler/actions/setup-gleam@v1
+        uses: tylerbutler/actions/setup-gleam@c3de10f5c576265f4910698528d949179081f25b # ratchet:tylerbutler/actions/setup-gleam@main
 
       - name: Lint examples (glinter)
         run: cd examples && gleam run -m glinter


### PR DESCRIPTION
## Summary
- Point `tylerbutler/actions/setup-gleam` at `main` instead of `v1` in `.github/workflows/ci.yml` (ratcheted SHA + pin comment) and in the `.github/workflows/ci-shared-actions.yml.template` used by the per-package reusable workflow.