### PR TITLE
ci(workflows): scope lint-examples deps to the examples directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Setup environment
         uses: tylerbutler/actions/setup-gleam@c3de10f5c576265f4910698528d949179081f25b # ratchet:tylerbutler/actions/setup-gleam@main
+        with:
+          working-directory: examples
 
       - name: Lint examples (glinter)
         run: cd examples && gleam run -m glinter


### PR DESCRIPTION
## Summary
- Point the `lint-examples` job's `setup-gleam` step at `working-directory: examples`, so it fetches and caches only the hex packages `examples/` actually depends on.
- Previously the step used the default root working directory, which ran `just deps` and downloaded dependencies for all 12 workspace packages (unneeded for linting examples) while `examples`'s own deps were never cached and were re-fetched from hex on every run.