### PR TITLE
fix(ci): rewrite all path deps and de-fatalize lockfile refresh

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,10 @@ jobs:
             lattice_registers:packages/lattice_registers/gleam.toml
             lattice_sets:packages/lattice_sets/gleam.toml
             lattice_maps:packages/lattice_maps/gleam.toml
+            lattice_sequence:packages/lattice_sequence/gleam.toml
+            lattice_text_core:packages/lattice_text_core/gleam.toml
+            lattice_text:packages/lattice_text/gleam.toml
+            lattice_fugue:packages/lattice_fugue/gleam.toml
           hex-api-key: ${{ secrets.HEXPM_API_KEY }}
 
   # After publishing, update manifest.toml lockfiles so they reflect the
@@ -69,6 +73,12 @@ jobs:
   update-lockfiles:
     needs: publish
     runs-on: ubuntu-latest
+    # Lockfile refresh is a best-effort convenience: it hits the Hex API for
+    # every package right after publish and can trip Hex rate limits. A failure
+    # here must not mark the Publish run as failed, otherwise downstream
+    # automation (e.g. auto-tag waiting on this workflow) aborts the rest of
+    # the release even though the package was published successfully.
+    continue-on-error: true
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Problem

The last release (#92) only published `lattice_text_core@1.0.0`. `lattice_sequence@1.0.0`, `lattice_text@1.0.0`, and `lattice_crdt@3.0.0` never reached Hex.

### Root causes

1. **Incomplete `replace-path-deps`** — `publish.yml` only rewrote path deps for `lattice_core`, `lattice_counters`, `lattice_registers`, `lattice_sets`, `lattice_maps`. The newer `lattice_sequence`, `lattice_text`, `lattice_text_core` (and `lattice_fugue`) were missing, so publishing `lattice_text` / `lattice_crdt` would leave those as path dependencies — which Hex rejects.
2. **Fatal lockfile refresh** — `lattice_text_core`'s Publish run succeeded at the `publish` job but failed at `update-lockfiles` (Hex API rate limit). That marked the whole run as failed, so the `auto-tag` workflow (which waits on Publish) aborted before pushing the remaining release tags.

## Fix

- Add `lattice_sequence`, `lattice_text_core`, `lattice_text`, `lattice_fugue` to `replace-path-deps`.
- Mark `update-lockfiles` as `continue-on-error` so a flaky lockfile refresh never blocks the release chain.

## Follow-up

After merge, the three missing tags will be pushed in dependency order to complete the release.