### PR TITLE
fix(ci): refresh only the published package's lockfile

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,13 +71,12 @@ jobs:
   # After publishing, update manifest.toml lockfiles so they reflect the
   # latest published versions. This keeps the repo in sync with Hex.
   update-lockfiles:
-    needs: publish
+    needs: [test, publish]
     runs-on: ubuntu-latest
-    # Lockfile refresh is a best-effort convenience: it hits the Hex API for
-    # every package right after publish and can trip Hex rate limits. A failure
-    # here must not mark the Publish run as failed, otherwise downstream
-    # automation (e.g. auto-tag waiting on this workflow) aborts the rest of
-    # the release even though the package was published successfully.
+    # Lockfile refresh is a best-effort convenience. It must not mark the
+    # Publish run as failed, otherwise downstream automation (e.g. auto-tag
+    # waiting on this workflow) aborts the rest of the release even though the
+    # package was published successfully.
     continue-on-error: true
     permissions:
       contents: write
@@ -98,14 +97,16 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup
 
-      - name: Refresh lockfiles
+      - name: Refresh lockfile
+        # Only refresh the manifest for the package that was just published.
+        # Sibling packages reference each other via path deps (not Hex), so
+        # refreshing the whole workspace here would issue N redundant Hex API
+        # requests per tag and trip Hex rate limits.
+        env:
+          PACKAGE: ${{ needs.test.outputs.package-path }}
         run: |
-          for pkg_dir in packages/lattice_*/; do
-            if [ -f "$pkg_dir/gleam.toml" ]; then
-              echo "Refreshing $pkg_dir manifest..."
-              (cd "$pkg_dir" && gleam deps download)
-            fi
-          done
+          echo "Refreshing $PACKAGE manifest..."
+          (cd "$PACKAGE" && gleam deps download)
 
       - name: Check for changes
         id: changes


### PR DESCRIPTION
## Problem

The `update-lockfiles` job in the Publish workflow ran `gleam deps download` for **every** workspace package (~12) on **every** tag publish. During a multi-package release that is dozens of redundant Hex API version-resolution requests, which trips the Hex API rate limit (`The rate limit for the Hex API has been exceeded for this IP`).

## Fix

Refresh only the manifest of the package that was just published (`needs.test.outputs.package-path`). Sibling packages reference each other via **path** dependencies, not Hex, so their manifests don't need refreshing when a sibling is published.

This cuts the job from N `gleam deps download` calls to 1 per tag.

Follow-up to #118.