### PR TITLE
fix(ci): drop redundant deps download and retry Hex-limited steps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,12 +32,31 @@ jobs:
           PACKAGE: ${{ steps.ws.outputs.tag-package-path }}
         run: |
           cd "$PACKAGE"
-          gleam deps download
+
+          # Shared GitHub runner IPs frequently trip the Hex API rate limit
+          # during version resolution. Retry the Hex-touching steps with
+          # exponential backoff so a transient rate-limit response doesn't fail
+          # the whole release. Dependency downloads happen implicitly on the
+          # first build/check, so no explicit `gleam deps download` is needed.
+          retry() {
+            local n=1 max=5 delay=30
+            until "$@"; do
+              if [ "$n" -ge "$max" ]; then
+                echo "Command failed after ${max} attempts: $*" >&2
+                return 1
+              fi
+              echo "Attempt ${n} failed; retrying in ${delay}s..." >&2
+              sleep "$delay"
+              n=$((n + 1))
+              delay=$((delay * 2))
+            done
+          }
+
           gleam format --check src test
-          gleam check
-          gleam build --warnings-as-errors
+          retry gleam check
+          retry gleam build --warnings-as-errors
           gleam test
-          gleam test --target javascript
+          retry gleam test --target javascript
           gleam docs build
 
   publish:


### PR DESCRIPTION
## Problem

Multi-package releases repeatedly failed the Publish workflow's `test` job with:

```
error: Hex API failure
    The rate limit for the Hex API has been exceeded for this IP
```

Two contributing factors:
1. The validation ran an explicit `gleam deps download` before `gleam check`/`build`, duplicating version resolution and adding an extra Hex API request per publish.
2. Shared GitHub runner IPs frequently trip the Hex API rate limit during resolution, so a transient 429 failed the release even when the package was fine.

## Fix

- Remove the redundant `gleam deps download` (deps download implicitly on first build/check).
- Wrap the Hex-touching steps (`gleam check`, `gleam build`, `gleam test --target javascript`) in a `retry` with exponential backoff (up to 5 attempts, 30s→480s).

Follow-up to #118 / #119 / #120.