### PR TITLE
chore: update workspace tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,4 +88,4 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v7
       - uses: ./.github/actions/setup
-      - run: trellis run docs --serial $(trellis list --releasable)
+      - run: trellis run docs --serial

--- a/.mise.toml
+++ b/.mise.toml
@@ -2,8 +2,8 @@
 # read by trellis doctor). This file adds the tools .tool-versions can't
 # express: backend-prefixed installs and env.
 [tools]
-node = "22"
-"github:tylerbutler/trellis" = "0.1.0"
+node = "24"
+"github:tylerbutler/trellis" = "0.2.0"
 
 [env]
 LC_ALL = "en_US.UTF-8"

--- a/gleam.toml
+++ b/gleam.toml
@@ -5,9 +5,8 @@
 
 [tools.trellis]
 members = ["packages/lattice_*", "examples"]
-# examples participates in task fan-out (format/lint/build/test) but is
-# excluded from changelog, versioning, tagging, and publishing.
-ignore-release = ["examples"]
+# examples participates in format/lint/build/test, but not docs or releases.
+exclude = { docs = ["examples"], release = ["examples"] }
 
 [tools.trellis.tasks.lint]
 command = "gleam run -m glinter"

--- a/justfile
+++ b/justfile
@@ -98,7 +98,7 @@ doctor:
 
 # Build documentation for published packages without bursting the Hex API
 docs:
-    trellis run docs --serial $(trellis list --releasable)
+    trellis run docs --serial
 
 # === CHANGELOG ===
 


### PR DESCRIPTION
## Summary

- upgrade the workspace pins to Node 24 and Trellis 0.2.0
- replace `ignore-release` with task-scoped `docs` and `release` exclusions
- simplify local and CI documentation commands to use Trellis exclusions

## Testing

- `just pr`
