### PR TITLE
ci: use trellis changelog preview outputs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,54 +45,41 @@ jobs:
 
       - name: Check changelog entries
         id: changelog
+        continue-on-error: true
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          # Non-zero exit means a changed releasable package has no fragment;
-          # that state is reported via the sticky comment, not a failed check.
-          trellis changelog check --base "$BASE_SHA" --head "$HEAD_SHA" --json > check.json || true
-          {
-            echo "has-entries=$(jq -r '."has-entries"' check.json)"
-            echo "needs-entry=$(jq -r '."needs-entry"' check.json)"
-            echo "preview<<TRELLIS_PREVIEW_EOF"
-            jq -r '.preview' check.json
-            echo "TRELLIS_PREVIEW_EOF"
-          } >> "$GITHUB_OUTPUT"
+          trellis changelog check \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --strictness warn \
+            --format github >> "$GITHUB_OUTPUT"
 
-      - name: Comment with changelog preview
-        if: steps.changelog.outputs.has-entries == 'true'
+      - name: Post changelog comment
+        if: >-
+          always() &&
+          steps.changelog.outputs.ok != '' &&
+          (steps.changelog.outputs.has_entries == 'true' ||
+           steps.changelog.outputs.needs_entry == 'true' ||
+           steps.changelog.outputs.invalid_fragments != '[]')
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # ratchet:marocchino/sticky-pull-request-comment@v2
         with:
           header: changelog
-          message: |
-            ## Changelog Preview
-
-            This PR adds the following changelog entries:
-
-            ${{ steps.changelog.outputs.preview }}
-
-      - name: Comment about missing changelog
-        if: steps.changelog.outputs.has-entries == 'false' && steps.changelog.outputs.needs-entry == 'true'
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # ratchet:marocchino/sticky-pull-request-comment@v2
-        with:
-          header: changelog
-          message: |
-            ## Missing Changelog Entry
-
-            This PR changes releasable packages but has no changelog fragment.
-
-            ${{ steps.changelog.outputs.preview }}
-
-            To add one, run:
-
-            ```
-            trellis changelog new --package <pkg> --kind <kind> --body "<description>"
-            ```
+          message: ${{ steps.changelog.outputs.preview }}
 
       - name: Remove changelog comment
-        if: steps.changelog.outputs.has-entries == 'false' && steps.changelog.outputs.needs-entry == 'false'
+        if: >-
+          always() &&
+          steps.changelog.outputs.ok != '' &&
+          steps.changelog.outputs.has_entries == 'false' &&
+          steps.changelog.outputs.needs_entry == 'false' &&
+          steps.changelog.outputs.invalid_fragments == '[]'
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # ratchet:marocchino/sticky-pull-request-comment@v2
         with:
           header: changelog
           delete: true
+
+      - name: Fail if changelog check did not run
+        if: always() && steps.changelog.outputs.ok == ''
+        run: exit 1

--- a/.mise.toml
+++ b/.mise.toml
@@ -3,7 +3,7 @@
 # express: backend-prefixed installs and env.
 [tools]
 node = "24"
-"github:tylerbutler/trellis" = "latest"
+"github:tylerbutler/trellis" = "0.9.0"
 
 [env]
 LC_ALL = "en_US.UTF-8"


### PR DESCRIPTION
## Summary

- pin Trellis 0.9.0 for local tooling and CI
- use native GitHub outputs for the changelog preview comment
- keep missing entries informational and remove stale comments

## Validation

- `mise exec -- trellis --version`
- `mise exec -- trellis doctor`
- `actionlint .github/workflows/pr.yml`
