### PR TITLE
chore: configure linguist attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.claude/** linguist-detectable=false
+website/** linguist-documentation=true


### PR DESCRIPTION
## Summary

- exclude `.claude` contents from GitHub Linguist language statistics
- classify `website` contents as documentation

## Testing

- verified both attributes with `git check-attr`
