### PR TITLE
ci: adapt changelog check to trellis 0.10

### DIFF
--- a/.changes/unreleased/lattice_fugue-1.toml
+++ b/.changes/unreleased/lattice_fugue-1.toml
@@ -1,6 +1,0 @@
-project = "lattice_fugue"
-kind = "Fixed"
-body = """
-try_delete_with_delta no longer uses an internal assertion
-
-The node lookup on the non-panicking delete path is now handled by returning DeleteIndexOutOfBounds instead of a let assert, so the try_ variant can never crash."""

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,7 +28,9 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: echo "$PR_TITLE" | npx commitlint
 
-  # Changelog entry check (informational: comments on the PR, never fails it)
+  # Changelog entry check. Missing entries never fail it (strictness = "warn"
+  # in gleam.toml); unparseable fragments do, since they block the next
+  # release no matter who committed them.
   changelog:
     name: Changelog
     runs-on: ubuntu-latest
@@ -45,6 +47,8 @@ jobs:
 
       - name: Check changelog entries
         id: changelog
+        # Invalid fragments exit 1 at every strictness setting. Keep going so
+        # the sticky comment lands before the verdict step fails the job.
         continue-on-error: true
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -53,12 +57,12 @@ jobs:
           trellis changelog check \
             --base "$BASE_SHA" \
             --head "$HEAD_SHA" \
-            --strictness warn \
             --format github >> "$GITHUB_OUTPUT"
 
+      # The preview is the whole comment: fragment counts, version bumps, and
+      # a collapsible render of the release each merge would cause.
       - name: Post changelog comment
         if: >-
-          always() &&
           steps.changelog.outputs.ok != '' &&
           (steps.changelog.outputs.has_entries == 'true' ||
            steps.changelog.outputs.needs_entry == 'true' ||
@@ -70,7 +74,6 @@ jobs:
 
       - name: Remove changelog comment
         if: >-
-          always() &&
           steps.changelog.outputs.ok != '' &&
           steps.changelog.outputs.has_entries == 'false' &&
           steps.changelog.outputs.needs_entry == 'false' &&
@@ -80,6 +83,8 @@ jobs:
           header: changelog
           delete: true
 
-      - name: Fail if changelog check did not run
-        if: always() && steps.changelog.outputs.ok == ''
+      # ok is 'true' unless a fragment failed to parse (strictness = warn) or
+      # the check itself never ran (outputs empty).
+      - name: Fail on invalid fragments
+        if: steps.changelog.outputs.ok != 'true'
         run: exit 1

--- a/.mise.toml
+++ b/.mise.toml
@@ -3,7 +3,7 @@
 # express: backend-prefixed installs and env.
 [tools]
 node = "24"
-"github:tylerbutler/trellis" = "0.9.0"
+"github:tylerbutler/trellis" = "latest"
 
 [env]
 LC_ALL = "en_US.UTF-8"

--- a/.mise.toml
+++ b/.mise.toml
@@ -3,7 +3,7 @@
 # express: backend-prefixed installs and env.
 [tools]
 node = "24"
-"github:tylerbutler/trellis" = "latest"
+"github:tylerbutler/trellis" = "0.10.0"
 
 [env]
 LC_ALL = "en_US.UTF-8"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ same two files; `mise install` sets up a dev machine.
 
 ### Workflows
 - **ci.yml**: `trellis doctor` + `trellis run format --check / check / lint / test / build --strict / docs` (Erlang + JavaScript targets)
-- **pr.yml**: PR title validation (commitlint) + changelog fragment check (`trellis changelog check`, sticky PR comment, non-blocking)
+- **pr.yml**: PR title validation (commitlint) + changelog fragment check (`trellis changelog check --format github`, sticky PR comment; missing entries warn via `changelog.strictness = "warn"`, invalid fragments fail)
 - **release.yml**: `trellis release pr` — batches unreleased fragments into per-package version bumps on the `release/pending` branch and opens/updates the release PR
 - **release-publish.yml**: On release-PR merge (or manual dispatch): `trellis publish --all-untagged` → `trellis tag create --push --github-release` → per-package lockfile refresh + follow-up PR
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -23,7 +23,7 @@ retry = { attempts = 5, initial_delay = "30s", multiplier = 2 }
 
 [tools.trellis.changelog]
 strictness = "warn"
-header-format = """
+header_format = """
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/gleam.toml
+++ b/gleam.toml
@@ -18,6 +18,12 @@ path-dep-requirement = "minor"
 retry = { attempts = 5, initial-delay = "30s", multiplier = 2 }
 
 [tools.trellis.changelog]
+# Missing entries warn instead of failing `changelog check` (trellis >= 0.10
+# scopes the check to fragments the branch itself wrote, so PRs riding on a
+# base-branch fragment now report a missing entry). Invalid fragments still
+# fail at every strictness. Config, not a CI flag, so local runs answer the
+# way CI does.
+strictness = "warn"
 header-format = """
 # Changelog
 


### PR DESCRIPTION
## Description

Trellis 0.10 made `changelog check` branch-scoped: only fragments the PR branch itself wrote satisfy the check, so one unreleased fragment on `main` can no longer excuse every later PR touching the same package. Its `--format github` preview also grew into a complete PR comment (fragment counts, version bumps, and a collapsible render of the release the merge would cause). This updates the workspace to match.

- **`gleam.toml`**: set `changelog.strictness = "warn"` so a missing entry reports without failing — in config rather than a CI flag, so local runs answer the way CI does.
- **`.github/workflows/pr.yml`**: post the check's `preview` output verbatim as the sticky comment, replacing the hand-written comment bodies and `jq` parsing of `--json`. The job now fails when `ok != 'true'` — i.e. on unparseable fragments, which block the next release regardless of who committed them — while missing entries only comment.
- **`.mise.toml`**: track trellis `latest` (currently 0.10.0).
- **`CLAUDE.md`**: refresh the pr.yml workflow description.