### PR TITLE
fix(text): return neutral deltas for no-op edits

### DIFF
--- a/.changes/unreleased/lattice_text-1.toml
+++ b/.changes/unreleased/lattice_text-1.toml
@@ -1,0 +1,6 @@
+package = "lattice_text"
+kind = "Fixed"
+body = """
+Return empty deltas for no-op text edits
+
+Empty inserts, appends, ranges, and replacements no longer return the entire document as their delta."""

--- a/.changes/unreleased/lattice_text_core-1.toml
+++ b/.changes/unreleased/lattice_text_core-1.toml
@@ -1,0 +1,6 @@
+package = "lattice_text_core"
+kind = "Added"
+body = """
+Add neutral-delta support for empty grapheme deletions
+
+Use `delete_graphemes_with_empty_delta` to return a backend-neutral delta for empty ranges while preserving the existing `delete_graphemes` API."""

--- a/.changes/unreleased/lattice_text_core-1.toml
+++ b/.changes/unreleased/lattice_text_core-1.toml
@@ -1,6 +1,6 @@
 package = "lattice_text_core"
-kind = "Added"
+kind = "Fixed"
 body = """
-Add neutral-delta support for empty grapheme deletions
+Return backend deltas for empty grapheme inserts
 
-Use `delete_graphemes_with_empty_delta` to return a backend-neutral delta for empty ranges while preserving the existing `delete_graphemes` API."""
+Empty grapheme inserts now call the backend insertion function so it can return a neutral delta."""

--- a/packages/lattice_fugue/src/lattice_fugue/sequence.gleam
+++ b/packages/lattice_fugue/src/lattice_fugue/sequence.gleam
@@ -120,7 +120,7 @@ pub fn new(replica_id: ReplicaId) -> Sequence(a) {
 /// The result is the neutral element when merged into `sequence`, and is
 /// useful when a valid operation makes no change.
 pub fn empty_delta(sequence: Sequence(a)) -> Sequence(a) {
-  Sequence(replica_id: sequence.replica_id, counter: 0, nodes: dict.new())
+  new(sequence.replica_id)
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/lattice_fugue/src/lattice_fugue/sequence.gleam
+++ b/packages/lattice_fugue/src/lattice_fugue/sequence.gleam
@@ -115,6 +115,14 @@ pub fn new(replica_id: ReplicaId) -> Sequence(a) {
   Sequence(replica_id: replica_id, counter: 0, nodes: dict.new())
 }
 
+/// Return an empty delta carrying this sequence's replica identity.
+///
+/// The result is the neutral element when merged into `sequence`, and is
+/// useful when a valid operation makes no change.
+pub fn empty_delta(sequence: Sequence(a)) -> Sequence(a) {
+  Sequence(replica_id: sequence.replica_id, counter: 0, nodes: dict.new())
+}
+
 // ---------------------------------------------------------------------------
 // Traversal
 // ---------------------------------------------------------------------------

--- a/packages/lattice_text/src/lattice_text/text.gleam
+++ b/packages/lattice_text/src/lattice_text/text.gleam
@@ -16,6 +16,7 @@
 //// text.value(doc)  // -> ""
 //// ```
 
+import gleam/bool
 import gleam/dynamic/decode
 import gleam/int
 import gleam/json
@@ -483,17 +484,8 @@ fn delete_graphemes_with_delta(
   start: Int,
   end: Int,
 ) -> Result(#(sequence.Sequence(String), sequence.Sequence(String)), RangeError) {
-  case start == end {
-    True -> Ok(#(seq, empty_sequence_delta(seq)))
-    False ->
-      grapheme.delete_graphemes(
-        seq,
-        start,
-        end,
-        delete_grapheme,
-        sequence.merge,
-      )
-  }
+  use <- bool.guard(start == end, Ok(#(seq, empty_sequence_delta(seq))))
+  grapheme.delete_graphemes(seq, start, end, delete_grapheme, sequence.merge)
 }
 
 fn empty_sequence_delta(

--- a/packages/lattice_text/src/lattice_text/text.gleam
+++ b/packages/lattice_text/src/lattice_text/text.gleam
@@ -483,22 +483,23 @@ fn delete_graphemes_with_delta(
   start: Int,
   end: Int,
 ) -> Result(#(sequence.Sequence(String), sequence.Sequence(String)), RangeError) {
-  grapheme.delete_graphemes_with_empty_delta(
-    seq,
-    start,
-    end,
-    delete_grapheme,
-    sequence.merge,
-    empty_sequence_delta,
-  )
+  case start == end {
+    True -> Ok(#(seq, empty_sequence_delta(seq)))
+    False ->
+      grapheme.delete_graphemes(
+        seq,
+        start,
+        end,
+        delete_grapheme,
+        sequence.merge,
+      )
+  }
 }
 
 fn empty_sequence_delta(
   seq: sequence.Sequence(String),
 ) -> sequence.Sequence(String) {
-  let assert Ok(#(_state, delta)) =
-    sequence.try_insert_many_with_delta(seq, 0, [])
-  delta
+  sequence.insert_many_with_delta(seq, 0, []).1
 }
 
 fn delete_grapheme(

--- a/packages/lattice_text/src/lattice_text/text.gleam
+++ b/packages/lattice_text/src/lattice_text/text.gleam
@@ -285,7 +285,6 @@ pub fn try_replace_range_with_delta(
     |> result.map_error(insert_error_to_range_error),
   )
   let delta = case start == end, graphemes {
-    True, [] -> updated
     True, _ -> insert_delta
     False, [] -> delete_delta
     False, _ -> sequence.merge(delete_delta, insert_delta)
@@ -484,7 +483,22 @@ fn delete_graphemes_with_delta(
   start: Int,
   end: Int,
 ) -> Result(#(sequence.Sequence(String), sequence.Sequence(String)), RangeError) {
-  grapheme.delete_graphemes(seq, start, end, delete_grapheme, sequence.merge)
+  grapheme.delete_graphemes_with_empty_delta(
+    seq,
+    start,
+    end,
+    delete_grapheme,
+    sequence.merge,
+    empty_sequence_delta,
+  )
+}
+
+fn empty_sequence_delta(
+  seq: sequence.Sequence(String),
+) -> sequence.Sequence(String) {
+  let assert Ok(#(_state, delta)) =
+    sequence.try_insert_many_with_delta(seq, 0, [])
+  delta
 }
 
 fn delete_grapheme(

--- a/packages/lattice_text/test/text/text_test.gleam
+++ b/packages/lattice_text/test/text/text_test.gleam
@@ -168,6 +168,22 @@ pub fn merge_applies_multi_character_insert_delta_test() {
   |> expect.to_equal(updated)
 }
 
+pub fn empty_insert_returns_empty_delta_test() {
+  let base = text.new(rid("A")) |> text.insert(0, "abc")
+  let #(updated, delta) = text.insert_with_delta(base, 1, "")
+
+  expect.to_equal(updated, base)
+  text.value(delta) |> expect.to_equal("")
+}
+
+pub fn empty_append_returns_empty_delta_test() {
+  let base = text.new(rid("A")) |> text.insert(0, "abc")
+  let #(updated, delta) = text.append_with_delta(base, "")
+
+  expect.to_equal(updated, base)
+  text.value(delta) |> expect.to_equal("")
+}
+
 pub fn merge_applies_delete_delta_test() {
   let base = text.new(rid("A")) |> text.insert(0, "x")
   let #(updated, delta) = text.delete_with_delta(base, 0)
@@ -261,6 +277,14 @@ pub fn delete_range_empty_range_is_noop_test() {
   |> expect.to_equal("abc")
 }
 
+pub fn delete_range_empty_range_returns_empty_delta_test() {
+  let base = text.new(rid("A")) |> text.insert(0, "abc")
+  let #(updated, delta) = text.delete_range_with_delta(base, 1, 1)
+
+  expect.to_equal(updated, base)
+  text.value(delta) |> expect.to_equal("")
+}
+
 pub fn delete_range_full_range_empties_text_test() {
   text.new(rid("A"))
   |> text.insert(0, "abc")
@@ -344,6 +368,14 @@ pub fn replace_range_empty_value_deletes_test() {
   |> text.replace_range(1, 3, "")
   |> text.value()
   |> expect.to_equal("ad")
+}
+
+pub fn replace_range_empty_edit_returns_empty_delta_test() {
+  let base = text.new(rid("A")) |> text.insert(0, "abc")
+  let #(updated, delta) = text.replace_range_with_delta(base, 1, 1, "")
+
+  expect.to_equal(updated, base)
+  text.value(delta) |> expect.to_equal("")
 }
 
 pub fn try_replace_range_invalid_range_returns_error_test() {

--- a/packages/lattice_text_core/src/lattice_text_core/grapheme.gleam
+++ b/packages/lattice_text_core/src/lattice_text_core/grapheme.gleam
@@ -99,9 +99,8 @@ pub fn insert_graphemes(
 /// - `merge` joins two deltas.
 ///
 /// Repeatedly deletes at `start`, since each deletion shifts the following
-/// graphemes left. An empty range preserves the historical behavior of
-/// returning the unchanged state as its delta. Use
-/// `delete_graphemes_with_empty_delta` when the backend has a neutral delta.
+/// graphemes left. An empty range is a no-op whose delta is the unchanged
+/// state.
 pub fn delete_graphemes(
   state: s,
   start: Int,
@@ -109,26 +108,8 @@ pub fn delete_graphemes(
   delete: fn(s, Int) -> Result(#(s, s), e),
   merge: fn(s, s) -> s,
 ) -> Result(#(s, s), e) {
-  delete_graphemes_with_empty_delta(state, start, end, delete, merge, fn(state) {
-    state
-  })
-}
-
-/// Delete the graphemes in `[start, end)`, returning a neutral delta when the
-/// range is empty.
-///
-/// This is equivalent to `delete_graphemes` for non-empty ranges.
-/// `empty_delta` returns the backend's neutral delta for the current state.
-pub fn delete_graphemes_with_empty_delta(
-  state: s,
-  start: Int,
-  end: Int,
-  delete: fn(s, Int) -> Result(#(s, s), e),
-  merge: fn(s, s) -> s,
-  empty_delta: fn(s) -> s,
-) -> Result(#(s, s), e) {
   case end - start {
-    count if count <= 0 -> Ok(#(state, empty_delta(state)))
+    count if count <= 0 -> Ok(#(state, state))
     count -> {
       use #(first_state, first_delta) <- result.try(delete(state, start))
       list.repeat(Nil, count - 1)

--- a/packages/lattice_text_core/src/lattice_text_core/grapheme.gleam
+++ b/packages/lattice_text_core/src/lattice_text_core/grapheme.gleam
@@ -73,8 +73,8 @@ pub fn slice(graphemes: List(String), start: Int, end: Int) -> String {
 ///
 /// Returns `Error` (via `index_out_of_bounds`) when `index` is outside
 /// `[0, length]`, mirroring the backend's own bounds contract even when the
-/// grapheme list is empty. An empty grapheme list at a valid index is a no-op
-/// whose delta is the unchanged state, and never reaches `insert_many`.
+/// grapheme list is empty. An empty grapheme list at a valid index is passed
+/// to `insert_many`, allowing the backend to return its neutral delta.
 pub fn insert_graphemes(
   graphemes: List(String),
   state: s,
@@ -84,10 +84,9 @@ pub fn insert_graphemes(
   index_out_of_bounds: fn(Int, Int) -> e,
 ) -> Result(#(s, s), e) {
   let len = length(state)
-  case graphemes, index < 0 || index > len {
-    _, True -> Error(index_out_of_bounds(index, len))
-    [], False -> Ok(#(state, state))
-    _, False -> insert_many(state, index, graphemes)
+  case index < 0 || index > len {
+    True -> Error(index_out_of_bounds(index, len))
+    False -> insert_many(state, index, graphemes)
   }
 }
 
@@ -100,8 +99,9 @@ pub fn insert_graphemes(
 /// - `merge` joins two deltas.
 ///
 /// Repeatedly deletes at `start`, since each deletion shifts the following
-/// graphemes left. An empty range is a no-op whose delta is the unchanged
-/// state.
+/// graphemes left. An empty range preserves the historical behavior of
+/// returning the unchanged state as its delta. Use
+/// `delete_graphemes_with_empty_delta` when the backend has a neutral delta.
 pub fn delete_graphemes(
   state: s,
   start: Int,
@@ -109,8 +109,26 @@ pub fn delete_graphemes(
   delete: fn(s, Int) -> Result(#(s, s), e),
   merge: fn(s, s) -> s,
 ) -> Result(#(s, s), e) {
+  delete_graphemes_with_empty_delta(state, start, end, delete, merge, fn(state) {
+    state
+  })
+}
+
+/// Delete the graphemes in `[start, end)`, returning a neutral delta when the
+/// range is empty.
+///
+/// This is equivalent to `delete_graphemes` for non-empty ranges.
+/// `empty_delta` returns the backend's neutral delta for the current state.
+pub fn delete_graphemes_with_empty_delta(
+  state: s,
+  start: Int,
+  end: Int,
+  delete: fn(s, Int) -> Result(#(s, s), e),
+  merge: fn(s, s) -> s,
+  empty_delta: fn(s) -> s,
+) -> Result(#(s, s), e) {
   case end - start {
-    count if count <= 0 -> Ok(#(state, state))
+    count if count <= 0 -> Ok(#(state, empty_delta(state)))
     count -> {
       use #(first_state, first_delta) <- result.try(delete(state, start))
       list.repeat(Nil, count - 1)

--- a/packages/lattice_text_core/test/grapheme/grapheme_test.gleam
+++ b/packages/lattice_text_core/test/grapheme/grapheme_test.gleam
@@ -36,10 +36,6 @@ fn insert_merge(a: List(String), b: List(String)) -> List(String) {
   list.append(a, b)
 }
 
-fn empty_delta(_state: List(String)) -> List(String) {
-  []
-}
-
 fn delete(
   state: List(String),
   index: Int,
@@ -187,18 +183,6 @@ pub fn delete_graphemes_range_test() {
 pub fn delete_graphemes_empty_range_is_noop_test() {
   grapheme.delete_graphemes(["a", "b"], 1, 1, delete, insert_merge)
   |> expect.to_equal(Ok(#(["a", "b"], ["a", "b"])))
-}
-
-pub fn delete_graphemes_empty_range_can_return_empty_delta_test() {
-  grapheme.delete_graphemes_with_empty_delta(
-    ["a", "b"],
-    1,
-    1,
-    delete,
-    insert_merge,
-    empty_delta,
-  )
-  |> expect.to_equal(Ok(#(["a", "b"], [])))
 }
 
 pub fn delete_graphemes_all_test() {

--- a/packages/lattice_text_core/test/grapheme/grapheme_test.gleam
+++ b/packages/lattice_text_core/test/grapheme/grapheme_test.gleam
@@ -36,6 +36,10 @@ fn insert_merge(a: List(String), b: List(String)) -> List(String) {
   list.append(a, b)
 }
 
+fn empty_delta(_state: List(String)) -> List(String) {
+  []
+}
+
 fn delete(
   state: List(String),
   index: Int,
@@ -144,7 +148,7 @@ pub fn insert_empty_graphemes_is_noop_test() {
     insert_many,
     IndexOutOfBounds,
   )
-  |> expect.to_equal(Ok(#(["a", "b"], ["a", "b"])))
+  |> expect.to_equal(Ok(#(["a", "b"], [])))
 }
 
 pub fn insert_empty_graphemes_at_bad_index_errors_test() {
@@ -183,6 +187,18 @@ pub fn delete_graphemes_range_test() {
 pub fn delete_graphemes_empty_range_is_noop_test() {
   grapheme.delete_graphemes(["a", "b"], 1, 1, delete, insert_merge)
   |> expect.to_equal(Ok(#(["a", "b"], ["a", "b"])))
+}
+
+pub fn delete_graphemes_empty_range_can_return_empty_delta_test() {
+  grapheme.delete_graphemes_with_empty_delta(
+    ["a", "b"],
+    1,
+    1,
+    delete,
+    insert_merge,
+    empty_delta,
+  )
+  |> expect.to_equal(Ok(#(["a", "b"], [])))
 }
 
 pub fn delete_graphemes_all_test() {

--- a/packages/lattice_text_fugue/src/lattice_text_fugue/text.gleam
+++ b/packages/lattice_text_fugue/src/lattice_text_fugue/text.gleam
@@ -29,6 +29,7 @@
 //// text.value(doc)  // -> "hello world"
 //// ```
 
+import gleam/bool
 import gleam/dynamic/decode
 import gleam/int
 import gleam/json
@@ -409,17 +410,8 @@ fn delete_graphemes_with_delta(
   start: Int,
   end: Int,
 ) -> Result(#(sequence.Sequence(String), sequence.Sequence(String)), RangeError) {
-  case start == end {
-    True -> Ok(#(seq, sequence.empty_delta(seq)))
-    False ->
-      grapheme.delete_graphemes(
-        seq,
-        start,
-        end,
-        delete_grapheme,
-        sequence.merge,
-      )
-  }
+  use <- bool.guard(start == end, Ok(#(seq, sequence.empty_delta(seq))))
+  grapheme.delete_graphemes(seq, start, end, delete_grapheme, sequence.merge)
 }
 
 fn delete_grapheme(

--- a/packages/lattice_text_fugue/src/lattice_text_fugue/text.gleam
+++ b/packages/lattice_text_fugue/src/lattice_text_fugue/text.gleam
@@ -409,14 +409,17 @@ fn delete_graphemes_with_delta(
   start: Int,
   end: Int,
 ) -> Result(#(sequence.Sequence(String), sequence.Sequence(String)), RangeError) {
-  grapheme.delete_graphemes_with_empty_delta(
-    seq,
-    start,
-    end,
-    delete_grapheme,
-    sequence.merge,
-    sequence.empty_delta,
-  )
+  case start == end {
+    True -> Ok(#(seq, sequence.empty_delta(seq)))
+    False ->
+      grapheme.delete_graphemes(
+        seq,
+        start,
+        end,
+        delete_grapheme,
+        sequence.merge,
+      )
+  }
 }
 
 fn delete_grapheme(

--- a/packages/lattice_text_fugue/src/lattice_text_fugue/text.gleam
+++ b/packages/lattice_text_fugue/src/lattice_text_fugue/text.gleam
@@ -250,7 +250,6 @@ pub fn try_replace_range_with_delta(
     |> result.map_error(insert_error_to_range_error),
   )
   let delta = case start == end, graphemes {
-    True, [] -> updated
     True, _ -> insert_delta
     False, [] -> delete_delta
     False, _ -> sequence.merge(delete_delta, insert_delta)
@@ -410,7 +409,14 @@ fn delete_graphemes_with_delta(
   start: Int,
   end: Int,
 ) -> Result(#(sequence.Sequence(String), sequence.Sequence(String)), RangeError) {
-  grapheme.delete_graphemes(seq, start, end, delete_grapheme, sequence.merge)
+  grapheme.delete_graphemes_with_empty_delta(
+    seq,
+    start,
+    end,
+    delete_grapheme,
+    sequence.merge,
+    sequence.empty_delta,
+  )
 }
 
 fn delete_grapheme(
@@ -444,7 +450,7 @@ fn insert_graphemes_with_delta(
 
 /// Insert a grapheme run into the Fugue backend, one node at a time, threading
 /// a merged delta. The Fugue backend has no batch primitive yet, so this folds
-/// the single-node insert; `insert_graphemes` never calls it with an empty run.
+/// the single-node insert.
 fn fugue_insert_many(
   seq: sequence.Sequence(String),
   index: Int,
@@ -454,7 +460,7 @@ fn fugue_insert_many(
   sequence.InsertError,
 ) {
   case graphemes {
-    [] -> Ok(#(seq, seq))
+    [] -> Ok(#(seq, sequence.empty_delta(seq)))
     [first, ..rest] -> {
       use #(first_state, first_delta) <- result.try(
         sequence.try_insert_with_delta(seq, index, first),

--- a/packages/lattice_text_fugue/test/text/text_test.gleam
+++ b/packages/lattice_text_fugue/test/text/text_test.gleam
@@ -147,6 +147,14 @@ pub fn delete_range_empty_is_noop_test() {
   |> expect.to_equal("abc")
 }
 
+pub fn delete_range_empty_returns_empty_delta_test() {
+  let base = doc() |> text.insert(0, "abc")
+  let #(updated, delta) = text.delete_range_with_delta(base, 1, 1)
+
+  expect.to_equal(updated, base)
+  text.value(delta) |> expect.to_equal("")
+}
+
 pub fn replace_range_test() {
   doc()
   |> text.insert(0, "abcd")
@@ -179,6 +187,14 @@ pub fn try_replace_range_out_of_bounds_test() {
   |> expect.to_be_true()
 }
 
+pub fn replace_range_empty_edit_returns_empty_delta_test() {
+  let base = doc() |> text.insert(0, "abc")
+  let #(updated, delta) = text.replace_range_with_delta(base, 1, 1, "")
+
+  expect.to_equal(updated, base)
+  text.value(delta) |> expect.to_equal("")
+}
+
 // ---------------------------------------------------------------------------
 // deltas and merge
 // ---------------------------------------------------------------------------
@@ -189,6 +205,22 @@ pub fn insert_delta_merges_into_peer_test() {
   text.merge(base, delta)
   |> text.value()
   |> expect.to_equal("hi!")
+}
+
+pub fn empty_insert_returns_empty_delta_test() {
+  let base = doc() |> text.insert(0, "abc")
+  let #(updated, delta) = text.insert_with_delta(base, 1, "")
+
+  expect.to_equal(updated, base)
+  text.value(delta) |> expect.to_equal("")
+}
+
+pub fn empty_append_returns_empty_delta_test() {
+  let base = doc() |> text.insert(0, "abc")
+  let #(updated, delta) = text.append_with_delta(base, "")
+
+  expect.to_equal(updated, base)
+  text.value(delta) |> expect.to_equal("")
 }
 
 pub fn concurrent_edits_converge_test() {


### PR DESCRIPTION
## Summary

- return neutral deltas for empty inserts and appends
- return neutral deltas for empty delete and replace ranges
- cover both sequence-backed text implementations with regressions
- keep neutral empty-range handling in each backend without expanding the shared API

## Testing

- `just format-check`
- `just test-pkg lattice_text_core`
- `just test-pkg lattice_text`
- `just test-pkg lattice_text_fugue`
- `just test-pkg lattice_fugue`

Closes #101
