### PR TITLE
fix(sequence): stack co-gap moves in op order

### DIFF
--- a/.changes/unreleased/lattice_sequence-1.toml
+++ b/.changes/unreleased/lattice_sequence-1.toml
@@ -1,0 +1,6 @@
+package = "lattice_sequence"
+kind = "Fixed"
+body = """
+Stack co-gap moves in op order regardless of how each resolved
+
+Concurrent moves landing in the same gap now stack left to right in op order even when some resolve against the gap's right boundary and others fall back to its left anchor. Previously a move that kept its right boundary was skipped by later movers in the same gap, so the visible mover order could disagree with the op order."""

--- a/packages/lattice_sequence/src/lattice_sequence/sequence.gleam
+++ b/packages/lattice_sequence/src/lattice_sequence/sequence.gleam
@@ -1068,8 +1068,9 @@ fn compare_clock_lists(
 
 /// Where a move's target gap resolves in the current element order.
 type MoveTarget {
-  /// Directly before this element; successive moves to the same target
-  /// stack left-to-right in op order naturally.
+  /// Directly before this element, i.e. at the right end of the gap this
+  /// element closes. `apply_moves` records the landing under that gap's
+  /// anchor so later movers resolving `AfterGap` stack after it.
   BeforeElement(ItemId)
   /// The gap after this element (`None` = document start). Successive moves
   /// into the same gap must also stack left-to-right in op order, which
@@ -1103,6 +1104,7 @@ fn apply_moves(
     list.fold(movers, dict.new(), fn(acc, item) {
       dict.insert(acc, item.id, Nil)
     })
+  let gap_anchors = base_gap_anchors(stripped)
   let #(result, _) =
     list.fold(movers, #(stripped, dict.new()), fn(acc, item) {
       let #(current, last_in_gap) = acc
@@ -1120,7 +1122,7 @@ fn apply_moves(
           {
             BeforeElement(right_id) -> #(
               insert_element_before_id(current, right_id, LiveEl(item)),
-              last_in_gap,
+              record_in_gap(last_in_gap, gap_anchors, right_id, item.id),
             )
             AtEnd -> #(list.append(current, [LiveEl(item)]), last_in_gap)
             AfterGap(anchor) -> #(
@@ -1136,6 +1138,46 @@ fn apply_moves(
       }
     })
   result
+}
+
+/// Map every element of the move-free base to the gap it closes: the id of
+/// the element immediately to its left, or `None` for the document start.
+///
+/// Movers are spliced into the gaps of this base, so `BeforeElement(right)`
+/// and `AfterGap(left)` name the same gap exactly when `left` is `right`'s
+/// base predecessor. Keying both on that anchor is what lets co-gap movers
+/// stack in op order no matter which path each one resolved through.
+fn base_gap_anchors(
+  elements: List(Element(a)),
+) -> Dict(ItemId, Option(ItemId)) {
+  let #(anchors, _) =
+    list.fold(elements, #(dict.new(), None), fn(acc, el) {
+      let #(anchors, previous) = acc
+      let id = element_id(el)
+      #(dict.insert(anchors, id, previous), Some(id))
+    })
+  anchors
+}
+
+/// Record a `BeforeElement` landing as the gap's rightmost mover so far.
+///
+/// Inserting before `right_id` always lands at the right end of that gap —
+/// every mover already placed there sits to its left — so the entry stays
+/// the correct splice point for the next mover in op order.
+///
+/// A `right_id` absent from the base is a mover placed earlier in this pass.
+/// Landing before it is not the gap's right end, so there is nothing to
+/// record and the previous entry stands.
+fn record_in_gap(
+  last_in_gap: Dict(Option(ItemId), ItemId),
+  gap_anchors: Dict(ItemId, Option(ItemId)),
+  right_id: ItemId,
+  mover: ItemId,
+) -> Dict(Option(ItemId), ItemId) {
+  case dict.get(gap_anchors, right_id) {
+    Ok(anchor) -> dict.insert(last_in_gap, anchor, mover)
+    Error(Nil) -> last_in_gap
+  }
 }
 
 fn splice_into_gap(

--- a/packages/lattice_sequence/test/sequence/sequence_test.gleam
+++ b/packages/lattice_sequence/test/sequence/sequence_test.gleam
@@ -402,3 +402,33 @@ pub fn move_after_descendant_does_not_drop_items_test() {
   |> expect.to_equal(["b", "a", "c"])
   sequence.length(moved) |> expect.to_equal(3)
 }
+
+pub fn co_gap_movers_stack_in_op_order_across_resolution_paths_test() {
+  // Three concurrent moves land in the same gap (between "L" and "R") but
+  // resolve differently: the ones anchored on the later-moved "e" lose their
+  // right boundary (it is itself a mover, stripped for this pass) and fall
+  // back to the gap's left anchor, while the one anchored on "R" keeps its
+  // right boundary. Whichever path each takes, they must stack left to right
+  // in op order.
+  let base =
+    sequence.new(rid("Z"))
+    |> sequence.insert(0, "L")
+    |> sequence.insert(1, "e")
+    |> sequence.insert(2, "R")
+    |> sequence.insert(3, "c")
+    |> sequence.insert(4, "d")
+    |> sequence.insert(5, "b")
+
+  // All three moves get the same counter, so replica id breaks the tie:
+  // A ("c") < B ("d") < C ("b").
+  let a = sequence.merge(sequence.new(rid("A")), base) |> sequence.move(3, 1)
+  let b = sequence.merge(sequence.new(rid("B")), base) |> sequence.move(4, 2)
+  let c = sequence.merge(sequence.new(rid("C")), base) |> sequence.move(5, 1)
+
+  // Moving "e" last turns it into a mover, so it is no longer a usable right
+  // boundary for the moves that anchored on it.
+  sequence.merge(sequence.merge(a, b), c)
+  |> sequence.move(3, 5)
+  |> sequence.values()
+  |> expect.to_equal(["L", "c", "d", "b", "R", "e"])
+}


### PR DESCRIPTION
Closes #102.

## Problem

`apply_moves` strips every moved item, then re-inserts the movers in op order, tracking the last mover placed in each gap (`last_in_gap`) so co-gap movers stack left to right. Only the `AfterGap` path recorded itself. A move that resolved `BeforeElement` landed at the gap's right end and left `last_in_gap` untouched, so the next `AfterGap` mover in the same gap spliced after a stale predecessor and jumped ahead of it.

The result stayed deterministic (no divergence), but the visible mover order contradicted the op-order stacking the docstring promises, and the same move set could interleave differently depending on how each move resolved.

## Repro

Three concurrent moves land between `L` and `R`. Two anchored on `e`, which is moved afterwards — `e` is a mover, so it is stripped for the pass and cannot serve as a right boundary; they fall back to `AfterGap(L)`. The third anchored on `R`, which survives, so it resolves `BeforeElement(R)`.

Op order is `c` < `d` < `b`; before this change the result was `["L", "c", "b", "d", "R", "e"]` — `b` ahead of `d`.

## Fix

Both resolutions name the same gap when the `AfterGap` anchor is the `BeforeElement` boundary's predecessor in the move-free base. `base_gap_anchors` computes that predecessor map once per pass, and the `BeforeElement` path records its landing under the resulting anchor.

Landing before `right_id` is always the gap's right end — every mover already placed there sits to its left — so the recorded entry stays the correct splice point for the next mover. When `right_id` is itself a mover placed earlier in the pass it has no base gap, the landing is not the gap's right end, and the previous entry stands.

## Validation

- New regression test `co_gap_movers_stack_in_op_order_across_resolution_paths_test` (fails before, passes after)
- `just test-all` — all 13 packages, Erlang and JavaScript, including the sequence property suite (merge commutativity/associativity, compaction)
- `just format`, `just check`, `just lint`, `just doctor`