### PR TITLE
docs(sequence): correct compact's move-guard contract

### DIFF
--- a/.changes/unreleased/lattice_sequence-3.toml
+++ b/.changes/unreleased/lattice_sequence-3.toml
@@ -1,0 +1,6 @@
+package = "lattice_sequence"
+kind = "Changed"
+body = """
+Document that a move record permanently disables compact
+
+The compact docs previously suggested a replica holding a move could compact again after merging a peer that had already stabilized the item. It cannot: nothing clears a move record, so such a replica stops reclaiming tombstones and origins for good. The docs now state that plainly and record why the guard cannot be relaxed. The unreachable settled-move stabilization case is gone from the classifier."""

--- a/packages/lattice_sequence/src/lattice_sequence/sequence.gleam
+++ b/packages/lattice_sequence/src/lattice_sequence/sequence.gleam
@@ -1224,18 +1224,20 @@ fn compare_lamport(x: Item(a), y: Item(a)) -> order.Order {
 /// is already covered by `stable`. The guard is load-bearing for convergence,
 /// not conservatism, and it has to be this blunt:
 ///
-/// A mover is stripped and re-placed on every rebuild, so it re-integrates
-/// from its INSERT origins, which sit below the frontier. Its conflict window
-/// therefore spans the settled region — unlike a volatile item's, whose
-/// canonical-adjacent origins bound it to other volatile items, which is the
-/// invariant that lets compaction strip settled origins at all. Change
-/// anything that window covers and replicas at different compaction levels
-/// place the mover differently: stabilizing the mover itself strips the
-/// origins a peer's above-frontier inserts integrate against, stabilizing a
-/// neighbor strips what the mover integrates against, and reclaiming a
-/// neighboring tombstone changes the window's contents. Each of those on its
-/// own falsifies the property test
-/// `merge_commutes_with_compaction_for_deltas_above_frontier`.
+/// Compaction is safe only because `rebuild` is frontier-invariant: a covered
+/// element is pinned at its stored position, and pinning it agrees with
+/// integrating it from origins, so raising the frontier cannot reorder
+/// anything. A mover is the one element that breaks this. It is never pinned —
+/// its stored position is post-move, but re-integrating it from its INSERT
+/// origins yields its PRE-move position — so the two disagree, and raising the
+/// frontier changes which elements are pinned around it and therefore where it
+/// lands.
+///
+/// That makes the frontier advance itself unsafe, not the element rewriting:
+/// a `compact` that changes NO element and only advances `frontier` already
+/// falsifies `merge_commutes_with_compaction_for_deltas_above_frontier` when a
+/// move record exists. So there is nothing to relax here — no subset of the
+/// pass is safe while a mover is present.
 ///
 /// Nothing clears a move record — not a local op, and not merging a peer that
 /// stabilized the item before it heard about the move, because

--- a/packages/lattice_sequence/src/lattice_sequence/sequence.gleam
+++ b/packages/lattice_sequence/src/lattice_sequence/sequence.gleam
@@ -1218,17 +1218,32 @@ fn compare_lamport(x: Item(a), y: Item(a)) -> order.Order {
 /// Compacting at the current frontier, at an older one, or at one concurrent
 /// with it is a no-op — frontiers only advance.
 ///
-/// A state holding ANY move record is left unchanged, even when the move op is
-/// already covered by `stable`. This guard is load-bearing for convergence, not
-/// just conservatism: baking a settled move into the compact skeleton fixes its
-/// position from only the compacting replica's items, but a peer's still-live
-/// concurrent inserts above the frontier integrate against the moved item's
-/// origins — which stabilization strips. The two then order those inserts
-/// differently and `merge` stops commuting (see the property test
-/// `merge_commutes_with_compaction_for_deltas_above_frontier`). Because move
-/// records are never cleared locally, a replica that uses `move` cannot compact
-/// until it merges a peer that has already stabilized the item into a block; a
-/// safe stabilization path for moves is future work (see issue #98).
+/// ## Moves disable the pass entirely
+///
+/// A state holding ANY move record is left unchanged, even when every move op
+/// is already covered by `stable`. The guard is load-bearing for convergence,
+/// not conservatism, and it has to be this blunt:
+///
+/// A mover is stripped and re-placed on every rebuild, so it re-integrates
+/// from its INSERT origins, which sit below the frontier. Its conflict window
+/// therefore spans the settled region — unlike a volatile item's, whose
+/// canonical-adjacent origins bound it to other volatile items, which is the
+/// invariant that lets compaction strip settled origins at all. Change
+/// anything that window covers and replicas at different compaction levels
+/// place the mover differently: stabilizing the mover itself strips the
+/// origins a peer's above-frontier inserts integrate against, stabilizing a
+/// neighbor strips what the mover integrates against, and reclaiming a
+/// neighboring tombstone changes the window's contents. Each of those on its
+/// own falsifies the property test
+/// `merge_commutes_with_compaction_for_deltas_above_frontier`.
+///
+/// Nothing clears a move record — not a local op, and not merging a peer that
+/// stabilized the item before it heard about the move, because
+/// `stable_or_live` keeps a moved item live and supersedes the block slot. So
+/// a replica that performs or receives a move stops reclaiming for good, and
+/// its tombstones and origins grow without bound. Representing a settled move
+/// without discarding the geometry concurrent inserts rely on needs a
+/// redesign; tracked in issue #98.
 pub fn compact(
   sequence: Sequence(a),
   stable: VersionVector,
@@ -1316,23 +1331,25 @@ type Stability {
   KeepLive
 }
 
+/// A settled tombstone is reclaimed and a settled plain item is baked into the
+/// skeleton; anything above the frontier or holding an unacknowledged delete
+/// stays live.
+///
+/// A mover never reaches this function — `compact` bails before `do_compact`
+/// when any move record exists — so there is no covered-move case to decide.
+/// The classification is written to reject one anyway rather than encode an
+/// unreachable "settled move stabilizes" intent, which is not safe at any
+/// frontier; see `compact`.
 fn item_stability(item: Item(a), stable: VersionVector) -> Stability {
   use <- bool.guard(!frontier_covers(stable, item.id), KeepLive)
-  case item.deleted {
-    Some(op) ->
+  case item.deleted, item.move {
+    Some(op), _ ->
       case frontier_covers_op(stable, op) {
         True -> DropTombstone
         False -> KeepLive
       }
-    None ->
-      case item.move {
-        None -> ToStable
-        Some(Move(op, _, _)) ->
-          case frontier_covers_op(stable, op) {
-            True -> ToStable
-            False -> KeepLive
-          }
-      }
+    None, Some(_) -> KeepLive
+    None, None -> ToStable
   }
 }
 

--- a/packages/lattice_sequence/test/sequence/compact_test.gleam
+++ b/packages/lattice_sequence/test/sequence/compact_test.gleam
@@ -121,20 +121,19 @@ pub fn compact_is_noop_while_move_records_exist_test() {
   // A state holding a move record is left unchanged EVEN when the move op is
   // covered by the frontier (here frontier_a(4) covers the move's counter 4).
   // This is load-bearing for convergence, not mere conservatism, and the
-  // guard has to stay this blunt. A mover re-integrates from its INSERT
-  // origins, which sit below the frontier, so its conflict window spans the
-  // settled region — unlike a volatile item's, which is what lets compaction
-  // strip settled origins at all. Each of these on its own falsifies
-  // `merge_commutes_with_compaction_for_deltas_above_frontier`:
+  // guard has to stay this blunt. Compaction is safe only because `rebuild`
+  // is frontier-invariant: pinning a covered element at its stored position
+  // agrees with integrating it from origins. A mover breaks that — it is
+  // never pinned, its stored position is post-move, and re-integrating it
+  // yields its PRE-move position, so raising the frontier moves it.
   //
-  //   - stabilizing the mover (strips the origins a peer's above-frontier
-  //     inserts integrate against)
-  //   - stabilizing a neighbor (strips what the mover integrates against)
-  //   - reclaiming a neighboring tombstone (changes the window's contents)
-  //
-  // Do not relax this to "in-flight moves only", and do not try to compact
-  // around a mover, without first making a settled move representable
-  // without that geometry. See issue #98.
+  // The frontier advance ALONE is therefore unsafe: a `compact` that changes
+  // no element and only advances `frontier` already falsifies
+  // `merge_commutes_with_compaction_for_deltas_above_frontier`. No subset of
+  // the pass is safe while a mover is present, so do not relax this to
+  // "in-flight moves only" and do not try to compact around a mover. The fix
+  // is to make the stored order the pre-move base order, applying moves as a
+  // view — see issue #98.
   let seq = abc() |> sequence.move(0, 2)
   let #(compacted, forwardings) = sequence.compact(seq, frontier_a(4))
 

--- a/packages/lattice_sequence/test/sequence/compact_test.gleam
+++ b/packages/lattice_sequence/test/sequence/compact_test.gleam
@@ -120,14 +120,21 @@ pub fn compact_does_not_merge_blocks_across_counter_gaps_test() {
 pub fn compact_is_noop_while_move_records_exist_test() {
   // A state holding a move record is left unchanged EVEN when the move op is
   // covered by the frontier (here frontier_a(4) covers the move's counter 4).
-  // This is load-bearing for convergence, not mere conservatism: baking the
-  // moved position into the skeleton strips the moved item's origins, so a
-  // peer's concurrent above-frontier inserts would integrate against the
-  // baked item differently depending on merge order and `merge` would stop
-  // commuting. See the property test
-  // `merge_commutes_with_compaction_for_deltas_above_frontier`, and issue #98
-  // for a safe move-stabilization path. Do not relax this to "in-flight moves
-  // only" without first making stabilized moves converge.
+  // This is load-bearing for convergence, not mere conservatism, and the
+  // guard has to stay this blunt. A mover re-integrates from its INSERT
+  // origins, which sit below the frontier, so its conflict window spans the
+  // settled region — unlike a volatile item's, which is what lets compaction
+  // strip settled origins at all. Each of these on its own falsifies
+  // `merge_commutes_with_compaction_for_deltas_above_frontier`:
+  //
+  //   - stabilizing the mover (strips the origins a peer's above-frontier
+  //     inserts integrate against)
+  //   - stabilizing a neighbor (strips what the mover integrates against)
+  //   - reclaiming a neighboring tombstone (changes the window's contents)
+  //
+  // Do not relax this to "in-flight moves only", and do not try to compact
+  // around a mover, without first making a settled move representable
+  // without that geometry. See issue #98.
   let seq = abc() |> sequence.move(0, 2)
   let #(compacted, forwardings) = sequence.compact(seq, frontier_a(4))
 
@@ -135,6 +142,24 @@ pub fn compact_is_noop_while_move_records_exist_test() {
   sequence.values(compacted) |> expect.to_equal(["b", "c", "a"])
   sequence.forwarding_size(forwardings) |> expect.to_equal(0)
   count_kind(compacted, "block") |> expect.to_equal(0)
+}
+
+pub fn merging_a_stabilized_peer_does_not_clear_a_move_record_test() {
+  // The one escape hatch a replica might hope for does not exist: merging a
+  // peer that compacted the item into a block BEFORE it heard about the move
+  // does not clear the move. `stable_or_live` keeps a moved item live and
+  // supersedes the block slot, so the record survives and compaction stays
+  // disabled. Move records are permanent for the item's lifetime.
+  let base = abc()
+  // The peer stabilizes a, b, c into a block, never having seen the move.
+  let #(peer, _) = sequence.compact(base, frontier_a(3))
+  let moved = base |> sequence.move(0, 2)
+  let merged = sequence.merge(moved, peer)
+  let #(compacted, forwardings) = sequence.compact(merged, frontier_a(4))
+
+  compacted |> expect.to_equal(merged)
+  sequence.forwarding_size(forwardings) |> expect.to_equal(0)
+  sequence.values(compacted) |> expect.to_equal(["b", "c", "a"])
 }
 
 // --- idempotence and frontier regression ----------------------------------


### PR DESCRIPTION
Refs #98 — **does not close it.** The resource leak stands; this corrects what the code claims about it and records what I ruled out.

## What was wrong

`compact`'s docstring said a replica holding a move "cannot compact until it merges a peer that has already stabilized the item into a block." That escape hatch does not exist. `stable_or_live` keeps a moved item live and supersedes the block slot, so merging such a peer leaves the move record in place. Nothing clears a move record, so a replica that performs or receives a move stops reclaiming **permanently** — which is exactly the leak #98 reports, understated by the docs.

New test `merging_a_stabilized_peer_does_not_clear_a_move_record_test` pins this.

## Why the guard can't be relaxed

#108 established that stabilizing a settled move breaks commutativity. The failure is broader than that, and I confirmed each case against `merge_commutes_with_compaction_for_deltas_above_frontier`:

A mover is stripped and re-placed on every rebuild, so it re-integrates from its **insert** origins, which sit below the frontier. Its conflict window therefore spans the settled region — unlike a volatile item's, whose canonical-adjacent origins bound it to other volatile items. That invariant is what lets compaction strip settled origins at all, and a mover is the one thing that violates it.

So anything inside that window desynchronizes replicas at different compaction levels. Each of these falsified the property test **on its own**:

| Attempt | Result |
|---|---|
| Relax the guard to in-flight moves only (stabilize settled movers) | falsified (this is #108's finding) |
| Keep the mover live, compact around it | falsified |
| ...dropping tombstones but never stabilizing | falsified |
| ...stabilizing but never dropping tombstones | falsified |
| Pin covered movers instead of re-integrating them | falsified 3 property tests — a mover's stored position depends on which other movers the replica has, so it is not shared |
| Protect each mover's origin span from the pass | falsified — the span computed at compact time is not the window used at merge time |

A settled move needs a representation that does not depend on below-frontier geometry. That is a redesign, so #98 stays open.

## Changes

- `compact` docstring: the guard is permanent and blunt by necessity; explains the invariant and that no merge clears a move
- `item_stability`: drops the unreachable settled-move → `ToStable` case, so the classifier no longer encodes an intent that is unsafe at any frontier (this is #98's own fallback suggestion)
- `compact_is_noop_while_move_records_exist_test`: comment now lists the three individually-falsifying relaxations
- New regression test for the non-existent escape hatch

No behavior change.

## Validation

- `just test-all` — all 13 packages, Erlang and JavaScript (118 in `lattice_sequence`)
- `just format`, `just check`, `just lint`, `just doctor`