### PR TITLE
test: widen the property sweeps

### DIFF
--- a/packages/lattice_counters/test/property/counter_property_test.gleam
+++ b/packages/lattice_counters/test/property/counter_property_test.gleam
@@ -8,8 +8,10 @@ fn rid(id: String) {
   replica_id.new(id)
 }
 
+/// The workspace default. These ran at 10 cases, which is not enough sweep to
+/// exercise the convergence laws they assert.
 fn small_test_config() -> qcheck.Config {
-  qcheck.config(test_count: 10, max_retries: 3, seed: qcheck.seed(42))
+  qcheck.config(test_count: 1000, max_retries: 3, seed: qcheck.seed(42))
 }
 
 pub fn g_counter_simple_commutativity__test() {

--- a/packages/lattice_fugue/test/property/anchor_property_test.gleam
+++ b/packages/lattice_fugue/test/property/anchor_property_test.gleam
@@ -8,8 +8,10 @@ fn rid(id: String) {
   replica_id.new(id)
 }
 
+/// The workspace default. These ran at 10 cases, which is not enough sweep to
+/// exercise the convergence laws they assert.
 fn small_test_config() -> qcheck.Config {
-  qcheck.config(test_count: 10, max_retries: 3, seed: qcheck.seed(42))
+  qcheck.config(test_count: 1000, max_retries: 3, seed: qcheck.seed(42))
 }
 
 fn doc_of_length(n: Int) -> sequence.Sequence(Int) {

--- a/packages/lattice_fugue/test/property/sequence_property_test.gleam
+++ b/packages/lattice_fugue/test/property/sequence_property_test.gleam
@@ -8,8 +8,10 @@ fn rid(id: String) {
   replica_id.new(id)
 }
 
+/// The workspace default. These ran at 10 cases, which is not enough sweep to
+/// exercise the convergence laws they assert.
 fn small_test_config() -> qcheck.Config {
-  qcheck.config(test_count: 10, max_retries: 3, seed: qcheck.seed(42))
+  qcheck.config(test_count: 1000, max_retries: 3, seed: qcheck.seed(42))
 }
 
 fn doc(id: String, value: Int) {

--- a/packages/lattice_maps/test/property/advanced_property_test.gleam
+++ b/packages/lattice_maps/test/property/advanced_property_test.gleam
@@ -12,8 +12,10 @@ fn rid(id: String) {
   replica_id.new(id)
 }
 
+/// The workspace default. These ran at 10 cases, which is not enough sweep to
+/// exercise the convergence laws they assert.
 fn small_test_config() -> qcheck.Config {
-  qcheck.config(test_count: 10, max_retries: 3, seed: qcheck.seed(42))
+  qcheck.config(test_count: 1000, max_retries: 3, seed: qcheck.seed(42))
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/lattice_maps/test/property/map_property_test.gleam
+++ b/packages/lattice_maps/test/property/map_property_test.gleam
@@ -12,8 +12,10 @@ fn rid(id: String) {
   replica_id.new(id)
 }
 
+/// The workspace default. These ran at 10 cases, which is not enough sweep to
+/// exercise the convergence laws they assert.
 fn small_test_config() -> qcheck.Config {
-  qcheck.config(test_count: 10, max_retries: 3, seed: qcheck.seed(42))
+  qcheck.config(test_count: 1000, max_retries: 3, seed: qcheck.seed(42))
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/lattice_maps/test/property/serialization_property_test.gleam
+++ b/packages/lattice_maps/test/property/serialization_property_test.gleam
@@ -13,8 +13,10 @@ fn rid(id: String) {
   replica_id.new(id)
 }
 
+/// The workspace default. These ran at 10 cases, which is not enough sweep to
+/// exercise the convergence laws they assert.
 fn small_test_config() -> qcheck.Config {
-  qcheck.config(test_count: 10, max_retries: 3, seed: qcheck.seed(42))
+  qcheck.config(test_count: 1000, max_retries: 3, seed: qcheck.seed(42))
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/lattice_registers/test/property/register_property_test.gleam
+++ b/packages/lattice_registers/test/property/register_property_test.gleam
@@ -12,8 +12,10 @@ fn rid(id: String) {
   replica_id.new(id)
 }
 
+/// The workspace default. These ran at 10 cases, which is not enough sweep to
+/// exercise the convergence laws they assert.
 fn small_test_config() -> qcheck.Config {
-  qcheck.config(test_count: 10, max_retries: 3, seed: qcheck.seed(42))
+  qcheck.config(test_count: 1000, max_retries: 3, seed: qcheck.seed(42))
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/lattice_sequence/test/property/compact_property_test.gleam
+++ b/packages/lattice_sequence/test/property/compact_property_test.gleam
@@ -9,8 +9,14 @@ fn rid(id: String) {
   replica_id.new(id)
 }
 
+/// Compaction properties guard the convergence rules that are easiest to get
+/// wrong, so they run the widest sweep in the workspace. This is not a round
+/// number: a change that reordered documents under compaction passed the whole
+/// suite at `test_count: 100` and was only caught by raising this. Treat 100 as
+/// known-insufficient, and raise this further when touching the interaction
+/// between moves and compaction.
 fn small_test_config() -> qcheck.Config {
-  qcheck.config(test_count: 100, max_retries: 3, seed: qcheck.seed(11))
+  qcheck.config(test_count: 2000, max_retries: 3, seed: qcheck.seed(11))
 }
 
 fn seed_pair_generator() {

--- a/packages/lattice_sequence/test/property/sequence_property_test.gleam
+++ b/packages/lattice_sequence/test/property/sequence_property_test.gleam
@@ -8,8 +8,11 @@ fn rid(id: String) {
   replica_id.new(id)
 }
 
+/// Lower than the rest of the workspace because each case builds and merges
+/// whole random sequences — the per-case cost is an order of magnitude above
+/// the other CRDTs, and the JavaScript target is ~10x slower again.
 fn small_test_config() -> qcheck.Config {
-  qcheck.config(test_count: 10, max_retries: 3, seed: qcheck.seed(42))
+  qcheck.config(test_count: 200, max_retries: 3, seed: qcheck.seed(42))
 }
 
 fn doc(id: String, value: Int) {

--- a/packages/lattice_sets/test/property/set_property_test.gleam
+++ b/packages/lattice_sets/test/property/set_property_test.gleam
@@ -10,8 +10,10 @@ fn rid(id: String) {
   replica_id.new(id)
 }
 
+/// The workspace default. These ran at 10 cases, which is not enough sweep to
+/// exercise the convergence laws they assert.
 fn small_test_config() -> qcheck.Config {
-  qcheck.config(test_count: 10, max_retries: 3, seed: qcheck.seed(42))
+  qcheck.config(test_count: 1000, max_retries: 3, seed: qcheck.seed(42))
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/lattice_text/test/property/anchor_property_test.gleam
+++ b/packages/lattice_text/test/property/anchor_property_test.gleam
@@ -8,8 +8,10 @@ fn rid(id: String) {
   replica_id.new(id)
 }
 
+/// The workspace default. These ran at 10 cases, which is not enough sweep to
+/// exercise the convergence laws they assert.
 fn small_test_config() -> qcheck.Config {
-  qcheck.config(test_count: 10, max_retries: 3, seed: qcheck.seed(42))
+  qcheck.config(test_count: 1000, max_retries: 3, seed: qcheck.seed(42))
 }
 
 fn doc(value: String) {

--- a/packages/lattice_text/test/property/text_property_test.gleam
+++ b/packages/lattice_text/test/property/text_property_test.gleam
@@ -8,8 +8,10 @@ fn rid(id: String) {
   replica_id.new(id)
 }
 
+/// The workspace default. These ran at 10 cases, which is not enough sweep to
+/// exercise the convergence laws they assert.
 fn small_test_config() -> qcheck.Config {
-  qcheck.config(test_count: 10, max_retries: 3, seed: qcheck.seed(42))
+  qcheck.config(test_count: 1000, max_retries: 3, seed: qcheck.seed(42))
 }
 
 fn doc(id: String, value: String) {


### PR DESCRIPTION
Found while working #98.

## Problem

Every property test outside the compaction suite ran **`test_count: 10`**; the compaction suite ran 100.

```
lattice_counters, lattice_sets, lattice_registers, lattice_maps,
lattice_text, lattice_fugue, lattice_sequence/sequence_property   10
lattice_sequence/compact_property                                100
```

For a library whose public guarantees are merge commutativity, associativity, idempotency, and convergence across compaction, ten cases does not exercise the laws being asserted.

This is a demonstrated gap, not a precaution: while investigating #98 I built a candidate fix that reordered documents under compaction. It passed **all 119 tests** at the old counts. Raising the compaction sweep caught it immediately, via `compaction_preserves_visible_order`. A convergence regression of exactly the kind these tests exist to catch would have reached review clean.

## Change

| Suite | Before | After |
|---|---|---|
| Workspace default | 10 | 1000 |
| `lattice_sequence` compaction | 100 | 2000 |
| `lattice_sequence` sequence | 10 | 200 |

Each site records why it has the number it does, so they don't quietly drift back. The compaction suite's comment names 100 as known-insufficient and says to raise it further when touching the move/compaction interaction — which is where the #98 redesign will land.

`lattice_sequence/sequence_property` is deliberately lower than the workspace default: each case builds and merges whole random sequences, so its per-case cost is an order of magnitude above the other CRDTs, and the JavaScript target is ~10x slower again.

## Cost

Measured across both targets:

- `lattice_sequence`: ~6s → ~45s (JavaScript dominates — 8.8s Erlang vs 80s JS at the widest setting I tried, which is why the compaction sweep is 2000 rather than 5000)
- every other package: unchanged, all under 6s

## Validation

All suites pass at the new counts, Erlang and JavaScript — `just test-all`, `just check`, `just lint`, `just format`. No source changes; test configuration only, so no changelog fragment.