### PR TITLE
build: bump trellis to 0.10.1

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -3,7 +3,7 @@
 # express: backend-prefixed installs and env.
 [tools]
 node = "24"
-"github:tylerbutler/trellis" = "0.10.0"
+"github:tylerbutler/trellis" = "0.10.1"
 
 [env]
 LC_ALL = "en_US.UTF-8"


### PR DESCRIPTION
## Summary
- Bump the `github:tylerbutler/trellis` mise tool pin in `.mise.toml` from `0.10.0` to `0.10.1`.