### PR TITLE
feat(registers): expose timestamp and replica_id on LWWRegister

### DIFF
--- a/.changes/unreleased/lattice_registers-1.toml
+++ b/.changes/unreleased/lattice_registers-1.toml
@@ -1,0 +1,3 @@
+package = "lattice_registers"
+kind = "Added"
+body = "Expose `lww_register.timestamp` and `lww_register.replica_id`, two pure accessors mirroring `value`. Because `set` accepts only strictly greater timestamps, a caller stamping writes from a wall clock has to stay ahead of the timestamp already held — otherwise two writes inside the same clock tick are unordered and the second is silently dropped. Reading the timestamp back makes that possible, including seeding a logical clock from a decoded snapshot without paying a JSON encode per key. `replica_id` returns the replica that wrote the value currently held, which after a merge is the replica whose write won. Neither accessor exposes the constructor, so the opacity that keeps the merge rule enforceable is unchanged."

--- a/packages/lattice_registers/README.md
+++ b/packages/lattice_registers/README.md
@@ -37,7 +37,7 @@ pub fn main() {
 
 ## Notes
 
-- `LWWRegister` exposes `new`, `set`, `set_with_delta`, `merge`, `value`, `to_json`, and `from_json`.
+- `LWWRegister` exposes `new`, `set`, `set_with_delta`, `merge`, `value`, `timestamp`, `replica_id`, `to_json`, and `from_json`.
 - `MVRegister` exposes `new`, `set`, `set_with_delta`, `merge`, `value`, `to_json`, and `from_json`.
 - Use `LWWRegister` when a deterministic winner is acceptable.
 - Use `MVRegister` when application code should resolve concurrent writes.

--- a/packages/lattice_registers/src/lattice_registers/lww_register.gleam
+++ b/packages/lattice_registers/src/lattice_registers/lww_register.gleam
@@ -22,7 +22,9 @@ import gleam/dynamic/decode
 import gleam/int
 import gleam/json
 import gleam/order
-import lattice_core/replica_id.{type ReplicaId}
+
+// Aliased so the `replica_id` accessor below can take the obvious name.
+import lattice_core/replica_id.{type ReplicaId} as replica
 
 /// A register holding a single value alongside its write timestamp and
 /// replica identifier.
@@ -55,6 +57,13 @@ pub fn new(
 /// timestamp with the new ones. Otherwise returns the register unchanged.
 /// This ensures only strictly newer writes are accepted.
 /// The `replica_id` is preserved from the original register.
+///
+/// Note that the comparison is *strict*, so a wall clock is not a safe source
+/// on its own: it stalls for a millisecond at a time, and a second write
+/// inside the same tick is silently dropped even when it came from this same
+/// replica. Callers that write faster than their clock ticks should stamp
+/// `int.max(wall_clock, timestamp(register) + 1)`, which keeps every local
+/// write ordered while leaving `merge` commutative.
 ///
 /// See `set_with_delta` for the delta-state variant that also returns a
 /// small payload suitable for incremental sync (e.g. over websockets).
@@ -99,6 +108,37 @@ pub fn value(register: LWWRegister(a)) -> a {
   register.value
 }
 
+/// Return the timestamp of the write the register currently holds.
+///
+/// Because `set` accepts only strictly greater timestamps, a caller stamping
+/// writes from a wall clock needs to know the timestamp already held in order
+/// to stay ahead of it — two writes inside the same clock tick are otherwise
+/// unordered and the second is dropped. Reading this back from a decoded
+/// snapshot lets such a caller seed its logical clock before its first write.
+///
+/// ## Examples
+///
+/// ```gleam
+/// let register = lww_register.new("hello", 42, replica_id.new("node-a"))
+/// lww_register.timestamp(register)  // -> 42
+///
+/// // Stamp the next write so it cannot collide with the one held.
+/// let next = int.max(wall_clock_ms(), lww_register.timestamp(register) + 1)
+/// ```
+pub fn timestamp(register: LWWRegister(a)) -> Int {
+  register.timestamp
+}
+
+/// Return the replica that owns the value the register currently holds.
+///
+/// `set` preserves the original replica, so for a locally written register
+/// this is the replica that created it. After `merge` it is the replica whose
+/// write won, which makes it useful for provenance and for tie-breaking
+/// consistently with `merge` in downstream code.
+pub fn replica_id(register: LWWRegister(a)) -> ReplicaId {
+  register.replica_id
+}
+
 /// Merge two LWW-Registers by returning the one with the higher timestamp.
 ///
 /// When `a.timestamp > b.timestamp`, returns `a`. When `b.timestamp >
@@ -109,7 +149,7 @@ pub fn merge(a: LWWRegister(a), b: LWWRegister(a)) -> LWWRegister(a) {
   use <- bool.guard(a.timestamp > b.timestamp, a)
   use <- bool.guard(a.timestamp < b.timestamp, b)
   // Equal timestamps: use replica_id as deterministic tie-breaker
-  case replica_id.compare(a.replica_id, b.replica_id) {
+  case replica.compare(a.replica_id, b.replica_id) {
     order.Gt -> a
     order.Lt -> b
     order.Eq -> a
@@ -131,7 +171,7 @@ pub fn to_json(register: LWWRegister(String)) -> json.Json {
       json.object([
         #("value", json.string(register.value)),
         #("timestamp", json.int(register.timestamp)),
-        #("replica_id", json.string(replica_id.to_string(register.replica_id))),
+        #("replica_id", json.string(replica.to_string(register.replica_id))),
       ]),
     ),
   ])
@@ -158,7 +198,7 @@ pub fn from_json(
       decode.success(LWWRegister(
         value: value,
         timestamp: timestamp,
-        replica_id: replica_id.new(replica_id_str),
+        replica_id: replica.new(replica_id_str),
       ))
     })
     decode.success(state)

--- a/packages/lattice_registers/test/register/lww_register_test.gleam
+++ b/packages/lattice_registers/test/register/lww_register_test.gleam
@@ -1,3 +1,4 @@
+import gleam/int
 import lattice_core/replica_id
 import lattice_registers/lww_register
 import startest/expect
@@ -85,4 +86,81 @@ pub fn merge_commutativity_on_different_timestamps_test() {
   let merged_ba = lww_register.merge(reg_b, reg_a) |> lww_register.value
 
   expect.to_equal(merged_ab, merged_ba)
+}
+
+// Metadata accessors
+
+pub fn timestamp_returns_constructed_timestamp_test() {
+  lww_register.new("hello", 42, rid("test-replica"))
+  |> lww_register.timestamp
+  |> expect.to_equal(42)
+}
+
+pub fn timestamp_advances_after_accepted_set_test() {
+  lww_register.new("hello", 1, rid("test-replica"))
+  |> lww_register.set("world", 7)
+  |> lww_register.timestamp
+  |> expect.to_equal(7)
+}
+
+pub fn timestamp_unchanged_after_rejected_equal_set_test() {
+  lww_register.new("hello", 5, rid("test-replica"))
+  |> lww_register.set("world", 5)
+  |> lww_register.timestamp
+  |> expect.to_equal(5)
+}
+
+pub fn timestamp_unchanged_after_rejected_lower_set_test() {
+  lww_register.new("hello", 5, rid("test-replica"))
+  |> lww_register.set("world", 2)
+  |> lww_register.timestamp
+  |> expect.to_equal(5)
+}
+
+pub fn timestamp_after_merge_is_the_winners_test() {
+  let reg_a = lww_register.new("alpha", 10, rid("A"))
+  let reg_b = lww_register.new("beta", 20, rid("B"))
+
+  lww_register.merge(reg_a, reg_b)
+  |> lww_register.timestamp
+  |> expect.to_equal(20)
+}
+
+pub fn replica_id_returns_constructed_replica_test() {
+  lww_register.new("hello", 1, rid("test-replica"))
+  |> lww_register.replica_id
+  |> expect.to_equal(rid("test-replica"))
+}
+
+pub fn replica_id_survives_set_test() {
+  lww_register.new("hello", 1, rid("owner"))
+  |> lww_register.set("world", 2)
+  |> lww_register.replica_id
+  |> expect.to_equal(rid("owner"))
+}
+
+pub fn replica_id_after_tiebreak_merge_is_the_winners_test() {
+  let reg_a = lww_register.new("aaa", 5, rid("A"))
+  let reg_b = lww_register.new("bbb", 5, rid("B"))
+
+  // B > A lexicographically, so the merged register carries B's id
+  lww_register.merge(reg_a, reg_b)
+  |> lww_register.replica_id
+  |> expect.to_equal(rid("B"))
+}
+
+/// The bug from issue #154: a client that loads a snapshot can read the held
+/// timestamp back and seed a logical clock from it, so a write stamped with a
+/// wall clock that has not moved past the snapshot is no longer dropped.
+pub fn timestamp_seeds_a_logical_clock_test() {
+  let snapshot = lww_register.new("painted", 100, rid("peer"))
+
+  // A fresh client whose wall clock reads 100 — the same millisecond.
+  let wall_clock = 100
+  let seeded = int.max(wall_clock, lww_register.timestamp(snapshot) + 1)
+
+  let erased = lww_register.set(snapshot, "erased", seeded)
+
+  expect.to_equal(lww_register.value(erased), "erased")
+  expect.to_equal(lww_register.timestamp(erased), 101)
 }

--- a/packages/lattice_registers/test/serialization/register_json_test.gleam
+++ b/packages/lattice_registers/test/serialization/register_json_test.gleam
@@ -1,3 +1,4 @@
+import gleam/int
 import gleam/json
 import gleam/list
 import gleam/string
@@ -46,13 +47,53 @@ pub fn lww_register_from_json_wrong_version_rejected_test() {
   }
 }
 
+pub fn lww_register_round_trip_preserves_metadata_test() {
+  let reg = lww_register.new("hello", 42, rid("test-replica"))
+  let json_str = json.to_string(lww_register.to_json(reg))
+  case lww_register.from_json(json_str) {
+    Ok(decoded) -> {
+      expect.to_equal(lww_register.timestamp(decoded), 42)
+      expect.to_equal(lww_register.replica_id(decoded), rid("test-replica"))
+    }
+    Error(_) -> expect.to_be_true(False)
+  }
+}
+
+/// The bootstrap case from issue #154: a client joining against a checkpoint
+/// written by a replica whose clock ran ahead seeds its own clock from the
+/// decoded register, so its first write to the key is not lost.
+pub fn lww_register_snapshot_seeds_a_logical_clock_test() {
+  // A peer checkpointed this at a wall-clock time ahead of ours.
+  let checkpoint =
+    json.to_string(
+      lww_register.to_json(lww_register.new("painted", 5000, rid("peer"))),
+    )
+
+  case lww_register.from_json(checkpoint) {
+    Ok(loaded) -> {
+      // Our wall clock is behind the checkpoint, so stamping from it alone
+      // would drop the write.
+      let our_clock = 4000
+      let stamped = int.max(our_clock, lww_register.timestamp(loaded) + 1)
+
+      let erased = lww_register.set(loaded, "erased", stamped)
+
+      expect.to_equal(lww_register.value(erased), "erased")
+      expect.to_equal(lww_register.timestamp(erased), 5001)
+    }
+    Error(_) -> expect.to_be_true(False)
+  }
+}
+
 pub fn lww_register_from_json_v1_compat_test() {
   let payload =
     "{\"type\":\"lww_register\",\"v\":1,\"state\":{\"value\":\"hello\",\"timestamp\":42}}"
   case lww_register.from_json(payload) {
     Ok(reg) -> {
-      lww_register.value(reg)
-      |> expect.to_equal("hello")
+      expect.to_equal(lww_register.value(reg), "hello")
+      expect.to_equal(lww_register.timestamp(reg), 42)
+      // v1 envelopes carry no replica_id; it decodes to the empty id.
+      expect.to_equal(lww_register.replica_id(reg), rid(""))
     }
     Error(_) -> expect.to_be_true(False)
   }

--- a/website/src/content/docs/guides/registers.md
+++ b/website/src/content/docs/guides/registers.md
@@ -57,6 +57,44 @@ pub fn main() {
 This keeps merges deterministic and replica-order independent even when clocks
 collide.
 
+### Stamping writes from a wall clock
+
+The strict comparison in `set` is what keeps `merge` commutative, but it makes a
+wall clock an unsafe timestamp source on its own. A millisecond clock stands
+still for a millisecond at a time, so two writes inside the same tick carry the
+same timestamp, and the second one is dropped — even though both came from the
+same replica and their order is not in doubt. Paint a cell and erase it in the
+same millisecond, and the erase vanishes.
+
+Only the writer knows its two writes are ordered, so the fix belongs on the
+stamping side: keep the wall clock, but never let it fall behind the timestamp
+already held. `lww_register.timestamp` reads that back.
+
+```gleam
+import gleam/int
+import lattice_registers/lww_register.{type LWWRegister}
+
+/// `now` is your own millisecond wall clock.
+pub fn stamp(register: LWWRegister(String), now: Int) -> Int {
+  int.max(now, lww_register.timestamp(register) + 1)
+}
+```
+
+That is the logical half of a [hybrid logical
+clock](https://cse.buffalo.edu/tech-reports/2014-04.pdf): the wall clock still
+drives the value forward, and the `+ 1` fallback keeps successive local writes
+strictly ordered when it does not move.
+
+The same applies across a restart. A client that loads a snapshot must seed its
+clock from what the snapshot holds, or its first write to a key can lose to a
+checkpoint written by a replica whose clock ran ahead. Fold `timestamp` over the
+decoded registers to recover that starting point — no JSON round trip needed.
+
+`lww_register.replica_id` reads back the other half of the metadata: the replica
+that wrote the value currently held. After a merge that is the replica whose
+write won, which makes it useful for provenance and for tie-breaking
+consistently with `merge` in your own code.
+
 ## MVRegister (Multi-Value Register)
 
 `MVRegister` keeps all concurrent values instead of picking one winner.


### PR DESCRIPTION
Fixes #154.

`LWWRegister` only exposed `value`, so callers couldn't read back the timestamp or replica it holds. This matters because `set` accepts a write only when its timestamp is strictly greater than the one already held — if two writes land in the same wall-clock tick, the second is silently dropped. Downstream code can avoid that by stamping `int.max(wall_clock, timestamp(register) + 1)`, but only if it can read the current timestamp — including after loading a snapshot, to seed its clock.

Adds two pure accessors:

```gleam
pub fn timestamp(register: LWWRegister(a)) -> Int
pub fn replica_id(register: LWWRegister(a)) -> ReplicaId
```

Both just read data the register already holds; the constructor stays opaque. Purely additive — `lattice_registers` 1.1.0 → 1.2.0.

Also updates `set`'s doc comment and the registers guide to explain the same-tick collision and how to avoid it, and aliases the `replica_id` module import to `replica` in `lww_register.gleam` so the new accessor can use the obvious name.