### PR TITLE
ci: fix jq paths for trellis tag plan --json schema

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           trellis tag plan --json > plan.json
           echo "Release set:"
-          jq -r '.[] | "\(.name) \(.version)"' plan.json
+          jq -r '.tags[] | "\(.name) \(.version)"' plan.json
 
       - name: Publish to Hex.pm
         env:
@@ -69,7 +69,7 @@ jobs:
       - name: Refresh lockfiles
         continue-on-error: true
         run: |
-          for pkg in $(jq -r '.[].name' plan.json); do
+          for pkg in $(jq -r '.tags[].name' plan.json); do
             trellis lockfile refresh --package "$pkg"
           done
           rm plan.json


### PR DESCRIPTION
## Problem

The Publish workflow failed on the release of #156 at the `Plan release set` step ([run 31556516858](https://github.com/tylerbutler/lattice/actions/runs/31556516858)):

```
jq: error (at plan.json:75): Cannot index string with string "version"
##[error]Process completed with exit code 5.
```

`trellis tag plan --json` (trellis 0.10.1) emits an object, not a top-level array:

```json
{ "schema": "trellis.tag_plan/2", "tags": [ { "name": ..., "version": ..., "tag": ... } ] }
```

`.[]` over an object iterates its *values*, so the first item was the string `"trellis.tag_plan/2"` and `.version` on a string is a hard error.

Because the failure happened before `trellis publish`, nothing shipped — the 7 packages in that release set are still unpublished on Hex.

## Fix

Point both jq expressions at `.tags[]`. Verified locally against real `trellis tag plan --json` output; both now yield the expected 7 packages.

## Recovery

After this merges, re-run the Publish workflow via `workflow_dispatch` (it checks out `main`). `trellis publish --all-untagged` is idempotent, so the release completes cleanly.