### PR TITLE
build: bump trellis to 0.11.2

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -3,7 +3,7 @@
 # express: backend-prefixed installs and env.
 [tools]
 node = "24"
-"github:tylerbutler/trellis" = "0.10.1"
+"github:tylerbutler/trellis" = "0.11.2"
 
 [env]
 LC_ALL = "en_US.UTF-8"

--- a/gleam.toml
+++ b/gleam.toml
@@ -12,7 +12,7 @@ command = "gleam run -m glinter"
 needs_deps = true
 
 [tools.trellis.publish]
-tag_format = "{name}-v{version}"
+exact_tag_format = "{name}-v{version}"
 path_dep_requirement = "minor"
 retry = { attempts = 5, initial_delay = "30s", multiplier = 2 }
 


### PR DESCRIPTION
## Why

Picks up [trellis#101](https://github.com/tylerbutler/trellis/pull/101), released in [v0.11.2](https://github.com/tylerbutler/trellis/releases/tag/v0.11.2) — the fix for the publish failure that stalled the last release ([run 31556845946](https://github.com/tylerbutler/lattice/actions/runs/31556845946)):

```
[lattice_registers] rewrote lattice_core -> ">= 1.0.0 and < 2.0.0"
[lattice_registers] $ gleam publish --yes
error: File IO failure ... build/packages/lattice_core/gleam.toml
```

trellis now clears a package's resolved dependency tree after rewriting path deps, so gleam no longer fails reading the local dependency it just dropped from the manifest. Every package in the release set except `lattice_presence` and `lattice_text_core` has a path dep.

## Config rename in the same commit

0.11.0 removed `publish.tag_format` in favour of `exact_tag_format` (pairing with `series_tag_format`). Left alone, the bump fails the workspace load outright:

```
error: `publish.tag_format` has been removed; it is renamed to `exact_tag_format`
```

Tags are unchanged — `trellis tag plan` under 0.11.2 produces the same seven tags (`lattice_registers-v1.2.0`, …) as 0.10.1 did.

## Verification

Against the real 0.11.2 binary, not a local build:

- `trellis doctor` — clean: 13 packages, 0 warnings, including the "no unrecognized or deprecated keys" check.
- `trellis tag plan --json` — same seven tags; the `.tags[]` jq paths from #157 still match.
- Release simulation (`publish --all-untagged` with `gleam publish` swapped for `gleam build`, so nothing shipped): `lattice_registers` and `lattice_sequence` both publish cleanly — they died at exactly this step before. It stops at `lattice_maps` with `lattice_registers has no versions in the range >= 1.2.0`, which is the simulation hitting its own limit: nothing was really uploaded, so the dependency it needs isn't on Hex. In a real run `lattice_registers` publishes first.

## After merging

Re-dispatch Publish on `main`. `lattice_presence` 1.0.1 already shipped in the failed run and will be skipped; the remaining six publish, then all seven get tags and GitHub Releases.